### PR TITLE
Add support for suppression APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,28 @@ Deleting a device will remove it from the customers device list in Customer.io.
 cio.DeleteDevice("5", "messaging-token")
 ```
 
+### Suppressing customers
+
+Suppressing a customer will delete them from Customer.io, and we will ignore all further attempts to identify or track activity for the suppressed customerID
+
+```go
+// Arguments
+// customerID (required) - the id of the customer the device you want to delete belongs to
+
+cio.Suppress("5")
+```
+
+### Unsuppressing customers
+
+Unsuppressing a customer will remove a customerID from our suppression list and we will start accepting new identify and track calls for the customer as normal
+
+```go
+// Arguments
+// customerID (required) - the id of the customer the device you want to delete belongs to
+
+cio.Unsuppress("5")
+```
+
 ## Contributing
 
 1. Fork it

--- a/customerio.go
+++ b/customerio.go
@@ -156,6 +156,9 @@ func (c *CustomerIO) DeleteDevice(customerID string, deviceID string) error {
 
 // Suppress a customer
 func (c *CustomerIO) Suppress(customerID string) error {
+	if customerID == "" {
+		return errors.New("customerID is a required field")
+	}
 	status, responseBody, err := c.request("POST", c.suppressURL(customerID), []byte{})
 
 	if err != nil {
@@ -169,6 +172,9 @@ func (c *CustomerIO) Suppress(customerID string) error {
 
 // Unsuppress a customer
 func (c *CustomerIO) Unsuppress(customerID string) error {
+	if customerID == "" {
+		return errors.New("customerID is a required field")
+	}
 	status, responseBody, err := c.request("POST", c.unsuppressURL(customerID), []byte{})
 
 	if err != nil {

--- a/customerio.go
+++ b/customerio.go
@@ -154,6 +154,32 @@ func (c *CustomerIO) DeleteDevice(customerID string, deviceID string) error {
 	return nil
 }
 
+// Suppress a customer
+func (c *CustomerIO) Suppress(customerID string) error {
+	status, responseBody, err := c.request("POST", c.suppressURL(customerID), []byte{})
+
+	if err != nil {
+		return err
+	} else if status != 200 {
+		return &CustomerIOError{status, c.suppressURL(customerID), responseBody}
+	}
+
+	return nil
+}
+
+// Unsuppress a customer
+func (c *CustomerIO) Unsuppress(customerID string) error {
+	status, responseBody, err := c.request("POST", c.unsuppressURL(customerID), []byte{})
+
+	if err != nil {
+		return err
+	} else if status != 200 {
+		return &CustomerIOError{status, c.unsuppressURL(customerID), responseBody}
+	}
+
+	return nil
+}
+
 func (c *CustomerIO) auth() string {
 	return base64.URLEncoding.EncodeToString([]byte(fmt.Sprintf("%v:%v", c.siteID, c.apiKey)))
 }
@@ -183,6 +209,14 @@ func (c *CustomerIO) deviceURL(customerID string) string {
 
 func (c *CustomerIO) deleteDeviceURL(customerID string, deviceID string) string {
 	return c.protocol() + path.Join(c.Host, "api/v1", "customers", customerID, "devices", deviceID)
+}
+
+func (c *CustomerIO) suppressURL(customerID string) string {
+	return c.protocol() + path.Join(c.Host, "api/v1", "customers", customerID, "suppress")
+}
+
+func (c *CustomerIO) unsuppressURL(customerID string) string {
+	return c.protocol() + path.Join(c.Host, "api/v1", "customers", customerID, "unsuppress")
 }
 
 func (c *CustomerIO) request(method, url string, body []byte) (status int, responseBody []byte, err error) {

--- a/customerio_test.go
+++ b/customerio_test.go
@@ -149,7 +149,7 @@ func TestUnsuppress(t *testing.T) {
 	cio.Identify("golang-test-unsuppress", map[string]interface{}{})
 	defer cio.Delete("golang-test-unsuppress")
 
-	cio.Suppress("golang-test-suppress")
+	cio.Suppress("golang-test-unsuppress")
 
 	if err := cio.Unsuppress("golang-test-unsuppress"); err != nil {
 		t.Error(err.Error())

--- a/customerio_test.go
+++ b/customerio_test.go
@@ -135,3 +135,23 @@ func TestDeleteDevice(t *testing.T) {
 		t.Error(err.Error())
 	}
 }
+
+func TestSuppress(t *testing.T) {
+	cio.Identify("golang-test-suppress", map[string]interface{}{})
+	defer cio.Delete("golang-test-suppress")
+
+	if err := cio.Suppress("golang-test-suppress"); err != nil {
+		t.Error(err.Error())
+	}
+}
+
+func TestUnsuppress(t *testing.T) {
+	cio.Identify("golang-test-unsuppress", map[string]interface{}{})
+	defer cio.Delete("golang-test-unsuppress")
+
+	cio.Suppress("golang-test-suppress")
+
+	if err := cio.Unsuppress("golang-test-unsuppress"); err != nil {
+		t.Error(err.Error())
+	}
+}


### PR DESCRIPTION
Adds handlers for the new [suppress](https://learn.customer.io/api/#apisuppress_add) and [unsuppress](https://learn.customer.io/api/#apisuppress_delete) endpoints, and associated tests