### PR TITLE
Encode the Customer ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Customerio
 
 A golang client for the [Customer.io](http://customer.io) [event API](https://app.customer.io/api/docs/index.html).
-*Tested with Go1.4*
+*Tested with Go1.10*
 
 Godoc here: [https://godoc.org/github.com/customerio/go-customerio](https://godoc.org/github.com/customerio/go-customerio)
 

--- a/customerio.go
+++ b/customerio.go
@@ -167,11 +167,11 @@ func (c *CustomerIO) protocol() string {
 }
 
 func (c *CustomerIO) customerURL(customerID string) string {
-	return c.protocol() + path.Join(c.Host, "api/v1", "customers", url.QueryEscape(customerID))
+	return c.protocol() + path.Join(c.Host, "api/v1", "customers", url.PathEscape(customerID))
 }
 
 func (c *CustomerIO) eventURL(customerID string) string {
-	return c.protocol() + path.Join(c.Host, "api/v1", "customers", url.QueryEscape(customerID), "events")
+	return c.protocol() + path.Join(c.Host, "api/v1", "customers", url.PathEscape(customerID), "events")
 }
 
 func (c *CustomerIO) anonURL() string {
@@ -179,11 +179,11 @@ func (c *CustomerIO) anonURL() string {
 }
 
 func (c *CustomerIO) deviceURL(customerID string) string {
-	return c.protocol() + path.Join(c.Host, "api/v1", "customers", url.QueryEscape(customerID), "devices")
+	return c.protocol() + path.Join(c.Host, "api/v1", "customers", url.PathEscape(customerID), "devices")
 }
 
 func (c *CustomerIO) deleteDeviceURL(customerID string, deviceID string) string {
-	return c.protocol() + path.Join(c.Host, "api/v1", "customers", url.QueryEscape(customerID), "devices", deviceID)
+	return c.protocol() + path.Join(c.Host, "api/v1", "customers", url.PathEscape(customerID), "devices", deviceID)
 }
 
 func (c *CustomerIO) request(method, url string, body []byte) (status int, responseBody []byte, err error) {

--- a/customerio.go
+++ b/customerio.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"path"
 	"strconv"
 )
@@ -166,11 +167,11 @@ func (c *CustomerIO) protocol() string {
 }
 
 func (c *CustomerIO) customerURL(customerID string) string {
-	return c.protocol() + path.Join(c.Host, "api/v1", "customers", customerID)
+	return c.protocol() + path.Join(c.Host, "api/v1", "customers", url.QueryEscape(customerID))
 }
 
 func (c *CustomerIO) eventURL(customerID string) string {
-	return c.protocol() + path.Join(c.Host, "api/v1", "customers", customerID, "events")
+	return c.protocol() + path.Join(c.Host, "api/v1", "customers", url.QueryEscape(customerID), "events")
 }
 
 func (c *CustomerIO) anonURL() string {
@@ -178,11 +179,11 @@ func (c *CustomerIO) anonURL() string {
 }
 
 func (c *CustomerIO) deviceURL(customerID string) string {
-	return c.protocol() + path.Join(c.Host, "api/v1", "customers", customerID, "devices")
+	return c.protocol() + path.Join(c.Host, "api/v1", "customers", url.QueryEscape(customerID), "devices")
 }
 
 func (c *CustomerIO) deleteDeviceURL(customerID string, deviceID string) string {
-	return c.protocol() + path.Join(c.Host, "api/v1", "customers", customerID, "devices", deviceID)
+	return c.protocol() + path.Join(c.Host, "api/v1", "customers", url.QueryEscape(customerID), "devices", deviceID)
 }
 
 func (c *CustomerIO) request(method, url string, body []byte) (status int, responseBody []byte, err error) {

--- a/customerio.go
+++ b/customerio.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"path"
 	"strconv"
 )
@@ -167,11 +166,11 @@ func (c *CustomerIO) protocol() string {
 }
 
 func (c *CustomerIO) customerURL(customerID string) string {
-	return c.protocol() + path.Join(c.Host, "api/v1", "customers", url.PathEscape(customerID))
+	return c.protocol() + path.Join(c.Host, "api/v1", "customers", encodeID(customerID))
 }
 
 func (c *CustomerIO) eventURL(customerID string) string {
-	return c.protocol() + path.Join(c.Host, "api/v1", "customers", url.PathEscape(customerID), "events")
+	return c.protocol() + path.Join(c.Host, "api/v1", "customers", encodeID(customerID), "events")
 }
 
 func (c *CustomerIO) anonURL() string {
@@ -179,11 +178,11 @@ func (c *CustomerIO) anonURL() string {
 }
 
 func (c *CustomerIO) deviceURL(customerID string) string {
-	return c.protocol() + path.Join(c.Host, "api/v1", "customers", url.PathEscape(customerID), "devices")
+	return c.protocol() + path.Join(c.Host, "api/v1", "customers", encodeID(customerID), "devices")
 }
 
 func (c *CustomerIO) deleteDeviceURL(customerID string, deviceID string) string {
-	return c.protocol() + path.Join(c.Host, "api/v1", "customers", url.PathEscape(customerID), "devices", deviceID)
+	return c.protocol() + path.Join(c.Host, "api/v1", "customers", encodeID(customerID), "devices", deviceID)
 }
 
 func (c *CustomerIO) request(method, url string, body []byte) (status int, responseBody []byte, err error) {
@@ -208,5 +207,4 @@ func (c *CustomerIO) request(method, url string, body []byte) (status int, respo
 	}
 
 	return status, responseBody, nil
-
 }

--- a/customerio_test.go
+++ b/customerio_test.go
@@ -2,7 +2,6 @@ package customerio
 
 import (
 	"fmt"
-	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -138,13 +137,19 @@ func TestDeleteDevice(t *testing.T) {
 }
 
 func TestStringEncoding(t *testing.T) {
-	encoded := encodeID(url.PathEscape("test path"))
-	if encoded != "test%20path" {
-		t.Errorf("got: %s, want: %s", encoded, url.PathEscape("test path"))
+	expected := "test%20path"
+	encoded := encodeID(expected)
+	if encoded != expected {
+		t.Errorf("got %s; want %s", encoded, expected)
 	}
 
 	encoded = encodeID("test path")
-	if encoded != "test%20path" {
-		t.Errorf("got: %s, want: %s", encoded, url.PathEscape("test path"))
+	if encoded != expected {
+		t.Errorf("got %s; want %s", encoded, expected)
+	}
+
+	encoded = encodeID(encodeID("test path"))
+	if encoded != expected {
+		t.Errorf("got %s; want %s", encoded, expected)
 	}
 }

--- a/customerio_test.go
+++ b/customerio_test.go
@@ -2,6 +2,7 @@ package customerio
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -133,5 +134,17 @@ func TestDeleteDevice(t *testing.T) {
 	err := cio.DeleteDevice("golang-test-deletedevice", "golang-test-delete")
 	if err != nil {
 		t.Error(err.Error())
+	}
+}
+
+func TestStringEncoding(t *testing.T) {
+	encoded := encodeID(url.PathEscape("test path"))
+	if encoded != "test%20path" {
+		t.Errorf("got: %s, want: %s", encoded, url.PathEscape("test path"))
+	}
+
+	encoded = encodeID("test path")
+	if encoded != "test%20path" {
+		t.Errorf("got: %s, want: %s", encoded, url.PathEscape("test path"))
 	}
 }

--- a/helpers.go
+++ b/helpers.go
@@ -16,7 +16,7 @@ const (
 	encodeFragment
 )
 
-// From https://golang.org/src/net/url/url.go?s=7976:8008#L691
+// From https://github.com/golang/go/blob/31d19c0ba34782d16b91e9d41aa88147e858bb34/src/net/url/url.go#L710
 // validEncodedPath reports whether s is a valid encoded path.
 // It must not contain any bytes that require escaping during path encoding.
 func validEncodedPath(s string) bool {
@@ -42,7 +42,7 @@ func validEncodedPath(s string) bool {
 	return true
 }
 
-// From https://golang.org/src/net/url/url.go?s=7976:8008#L101
+// From https://github.com/golang/go/blob/31d19c0ba34782d16b91e9d41aa88147e858bb34/src/net/url/url.go#L101
 // Return true if the specified character should be escaped when
 // appearing in a URL string, according to RFC 3986.
 //

--- a/helpers.go
+++ b/helpers.go
@@ -1,0 +1,133 @@
+package customerio
+
+import (
+	"net/url"
+)
+
+type encoding int
+
+const (
+	encodePath encoding = 1 + iota
+	encodePathSegment
+	encodeHost
+	encodeZone
+	encodeUserPassword
+	encodeQueryComponent
+	encodeFragment
+)
+
+// From https://golang.org/src/net/url/url.go?s=7976:8008#L691
+// validEncodedPath reports whether s is a valid encoded path.
+// It must not contain any bytes that require escaping during path encoding.
+func validEncodedPath(s string) bool {
+	for i := 0; i < len(s); i++ {
+		// RFC 3986, Appendix A.
+		// pchar = unreserved / pct-encoded / sub-delims / ":" / "@".
+		// shouldEscape is not quite compliant with the RFC,
+		// so we check the sub-delims ourselves and let
+		// shouldEscape handle the others.
+		switch s[i] {
+		case '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=', ':', '@':
+			// ok
+		case '[', ']':
+			// ok - not specified in RFC 3986 but left alone by modern browsers
+		case '%':
+			// ok - percent encoded, will decode
+		default:
+			if shouldEscape(s[i], encodePath) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// From https://golang.org/src/net/url/url.go?s=7976:8008#L101
+// Return true if the specified character should be escaped when
+// appearing in a URL string, according to RFC 3986.
+//
+// Please be informed that for now shouldEscape does not check all
+// reserved characters correctly. See golang.org/issue/5684.
+func shouldEscape(c byte, mode encoding) bool {
+	// §2.3 Unreserved characters (alphanum)
+	if 'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z' || '0' <= c && c <= '9' {
+		return false
+	}
+
+	if mode == encodeHost || mode == encodeZone {
+		// §3.2.2 Host allows
+		//	sub-delims = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
+		// as part of reg-name.
+		// We add : because we include :port as part of host.
+		// We add [ ] because we include [ipv6]:port as part of host.
+		// We add < > because they're the only characters left that
+		// we could possibly allow, and Parse will reject them if we
+		// escape them (because hosts can't use %-encoding for
+		// ASCII bytes).
+		switch c {
+		case '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=', ':', '[', ']', '<', '>', '"':
+			return false
+		}
+	}
+
+	switch c {
+	case '-', '_', '.', '~': // §2.3 Unreserved characters (mark)
+		return false
+
+	case '$', '&', '+', ',', '/', ':', ';', '=', '?', '@': // §2.2 Reserved characters (reserved)
+		// Different sections of the URL allow a few of
+		// the reserved characters to appear unescaped.
+		switch mode {
+		case encodePath: // §3.3
+			// The RFC allows : @ & = + $ but saves / ; , for assigning
+			// meaning to individual path segments. This package
+			// only manipulates the path as a whole, so we allow those
+			// last three as well. That leaves only ? to escape.
+			return c == '?'
+
+		case encodePathSegment: // §3.3
+			// The RFC allows : @ & = + $ but saves / ; , for assigning
+			// meaning to individual path segments.
+			return c == '/' || c == ';' || c == ',' || c == '?'
+
+		case encodeUserPassword: // §3.2.1
+			// The RFC allows ';', ':', '&', '=', '+', '$', and ',' in
+			// userinfo, so we must escape only '@', '/', and '?'.
+			// The parsing of userinfo treats ':' as special so we must escape
+			// that too.
+			return c == '@' || c == '/' || c == '?' || c == ':'
+
+		case encodeQueryComponent: // §3.4
+			// The RFC reserves (so we must escape) everything.
+			return true
+
+		case encodeFragment: // §4.1
+			// The RFC text is silent but the grammar allows
+			// everything, so escape nothing.
+			return false
+		}
+	}
+
+	if mode == encodeFragment {
+		// RFC 3986 §2.2 allows not escaping sub-delims. A subset of sub-delims are
+		// included in reserved from RFC 2396 §2.2. The remaining sub-delims do not
+		// need to be escaped. To minimize potential breakage, we apply two restrictions:
+		// (1) we always escape sub-delims outside of the fragment, and (2) we always
+		// escape single quote to avoid breaking callers that had previously assumed that
+		// single quotes would be escaped. See issue #19917.
+		switch c {
+		case '!', '(', ')', '*':
+			return false
+		}
+	}
+
+	// Everything else must be escaped.
+	return true
+}
+
+func encodeID(s string) string {
+	if !validEncodedPath(s) {
+		return url.PathEscape(s)
+	}
+	return s
+}


### PR DESCRIPTION
This PR encodes the Customer ID sent in API requests. It tries to detect Customer ID strings that have already been encoded to avoid re-encoding. 