### PR TITLE
Test w/ circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,59 @@
+version: 2.1
+
+commands:
+  gotest:
+    description: Run Golang tests using gotestsum
+    parameters:
+      version:
+        type: string
+        default: "go110"
+    steps:
+      - run: mkdir -p /tmp/test-results
+
+      - run: gotestsum --junitfile /tmp/test-results/<< parameters.version >>-unit-tests.xml -- -timeout 5m -p 1 ./...
+
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: raw-test-output
+      - store_test_results:
+          path: /tmp/test-results
+
+jobs:
+  go110:
+    docker:
+      - image: circleci/golang:1.10
+
+    working_directory: /go/src/github.com/customerio/go-customerio
+    steps:
+      - checkout
+      - gotest:
+          version: "go110"
+  go111:
+    docker:
+      - image: circleci/golang:1.11
+
+    working_directory: /go/src/github.com/customerio/go-customerio
+    steps:
+      - checkout
+      - gotest:
+          version: "go111"
+  go112:
+    docker:
+      - image: circleci/golang:1.12
+
+    working_directory: /go/src/github.com/customerio/go-customerio
+    steps:
+      - checkout
+      - gotest:
+          version: "go112"
+
+workflows:
+  version: 2
+  test:
+    jobs:
+    - go110:
+        context: cio-integration
+    - go111:
+        context: cio-integration
+    - go112:
+        context: cio-integration

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Customerio
+# go-customerio [![CircleCI](https://circleci.com/gh/customerio/go-customerio/tree/master.svg?style=svg)](https://circleci.com/gh/customerio/go-customerio/tree/master)
 
 A golang client for the [Customer.io](http://customer.io) [event API](https://app.customer.io/api/docs/index.html).
 *Tested with Go1.10*


### PR DESCRIPTION
Part of https://github.com/customerio/issues/issues/2786

This adds a CircleCI config to test the library for go 1.10+. We're using setting the required CIO site_id/api_key environment variables using a secure context in CircleCI. This allows tests to run against a live CIO test environment, however long term we should still address changing the tests to use a mock service as described in https://github.com/customerio/go-customerio/issues/8 to remove the need for a live test environment.