### PR TITLE
Allow user provided HTTP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,26 @@ which can be found on the [customer.io integration screen](https://manage.custom
 cio := customerio.NewCustomerIO("YOUR SITE ID", "YOUR API SECRET KEY")
 ```
 
+#### Using a custom http.Client
+
+By default the go-customerio library provides a minimal HTTP client:
+```go
+var DefaultClient = &http.Client{
+	Transport: &http.Transport{
+		MaxIdleConnsPerHost: 100,
+	},
+}
+```
+You can customize this client if your use case requires setting different values (such as a timeout):
+```go
+customClient := customerio.DefaultClient{
+  Timeout: time.Second * 5,
+}
+
+cio := customerio.NewCustomerIO("YOUR SITE ID", "YOUR API SECRET KEY")
+cio.Client = customClient
+```
+
 ### Identify logged in customers
 
 Tracking data of logged in customers is a key part of [Customer.io](http://customer.io). In order to

--- a/customerio.go
+++ b/customerio.go
@@ -17,7 +17,7 @@ type CustomerIO struct {
 	apiKey string
 	Host   string
 	SSL    bool
-	client *http.Client
+	Client *http.Client
 }
 
 // CustomerIOError is returned by any method that fails at the API level
@@ -31,15 +31,15 @@ func (e *CustomerIOError) Error() string {
 	return fmt.Sprintf("%v: %v %v", e.status, e.url, string(e.body))
 }
 
+var DefaultClient = &http.Client{
+	Transport: &http.Transport{
+		MaxIdleConnsPerHost: 100,
+	},
+}
+
 // NewCustomerIO creates a new CustomerIO object to perform requests on the supplied credentials
 func NewCustomerIO(siteID, apiKey string) *CustomerIO {
-	tr := &http.Transport{
-		MaxIdleConnsPerHost: 100,
-	}
-	client := &http.Client{
-		Transport: tr,
-	}
-	return &CustomerIO{siteID, apiKey, "track.customer.io", true, client}
+	return &CustomerIO{siteID, apiKey, "track.customer.io", true, DefaultClient}
 }
 
 // Identify identifies a customer and sets their attributes
@@ -258,7 +258,7 @@ func (c *CustomerIO) request(method, url string, body []byte) (status int, respo
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Content-Length", strconv.Itoa(len(body)))
 
-	resp, err := c.client.Do(req)
+	resp, err := c.Client.Do(req)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/customerio_test.go
+++ b/customerio_test.go
@@ -2,6 +2,7 @@ package customerio
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"testing"
 	"time"
@@ -151,5 +152,24 @@ func TestStringEncoding(t *testing.T) {
 	encoded = encodeID(encodeID("test path"))
 	if encoded != expected {
 		t.Errorf("got %s; want %s", encoded, expected)
+	}
+}
+
+func TestCustomClient(t *testing.T) {
+	expected := time.Second * 10
+	siteID := os.Getenv("CUSTOMERIO_SITE_ID")
+	apiKey := os.Getenv("CUSTOMERIO_API_KEY")
+
+	if siteID == "" || apiKey == "" {
+		t.Error("Must set CUSTOMERIO_SITE_ID and CUSTOMERIO_API_KEY environment variables to test this library")
+	}
+
+	customCIO := NewCustomerIO(siteID, apiKey)
+	customCIO.Client = &http.Client{
+		Timeout: time.Second * 10,
+	}
+
+	if customCIO.Client.Timeout != expected {
+		t.Errorf("got %v; want %v", customCIO.Client.Timeout, expected)
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/customerio/go-customerio/issues/17

👋 Hey Customer.io Team! Saw an issue filed on the Golang library and decided to take a crack at it. Let me know if there's anything y'all would change about this implementation, at a high level:
- exports the `*http.Client` property on the `CustomerIO` struct to allow user customization
- adds an exported `DefaultClient` var and simplifies the `NewCustomerIO()` func to use this
- adds a silly test to ensure the `Client` property of the `CustomerIO` struct can be modified

@hownowstephen you may be a good candidate to review this or to get it out to someone else from the backend team to review.