### PR TITLE
Region support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## March 24, 2021
+### Added
+- Support for EU region
+- Allow using custom `*http.Client`
+### Removed
+### Changed
+- `customerio.NewAPIClient` and `customerio.NewTrackClient`  have a new variadic parameter for options in order to choose US/EU region and/or customer HTTP client.
+
 ## December 3, 2020
 ### Added
 - Support for transactional api

--- a/README.md
+++ b/README.md
@@ -49,12 +49,13 @@ You'll be able to integrate **fully** with [Customer.io](http://customer.io) wit
 
 ### Setup
 
-Create an instance of the client with your [customer.io](http://customer.io) credentials
-which can be found on the [customer.io integration screen](https://manage.customer.io/integration).
+Create an instance of the client with your [Customer.io credentials](https://fly.customer.io/settings/api_credentials).
 
 ```go
-track := customerio.NewTrackClient("YOUR SITE ID", "YOUR API SECRET KEY")
+track := customerio.NewTrackClient("YOUR SITE ID", "YOUR API SECRET KEY", customerio.WithRegion(customerio.RegionUS))
 ```
+
+Your account region—`RegionUS` or `RegionEU`—is optional. If you do not specify your region, we assume that your account is based in the US (`RegionUS`). If your account is based in the EU and you do not provide the correct region, we'll route requests from the US to `RegionEU` accordingly, however this may cause data to be logged in the US. 
 
 ### Identify logged in customers
 
@@ -194,7 +195,7 @@ You can also send attachments with your message. Use `Attach` to encode attachme
 ```go
 import "github.com/customerio/go-customerio"
 
-client := customerio.NewAPIClient("<extapikey>");
+client := customerio.NewAPIClient("<extapikey>", customerio.WithRegion(customerio.RegionUS));
 
 // TransactionalMessageId — the ID of the transactional message you want to send.
 // To                     — the email address of your recipients.

--- a/api.go
+++ b/api.go
@@ -16,12 +16,17 @@ type APIClient struct {
 
 // NewAPIClient prepares a client for use with the Customer.io API, see: https://customer.io/docs/api/#apicoreintroduction
 // using an App API Key from https://fly.customer.io/settings/api_credentials?keyType=app
-func NewAPIClient(key string) *APIClient {
-	return &APIClient{
+func NewAPIClient(key string, opts ...option) *APIClient {
+	client := &APIClient{
 		Key:    key,
 		Client: http.DefaultClient,
 		URL:    "https://api.customer.io",
 	}
+
+	for _, opt := range opts {
+		opt.api(client)
+	}
+	return client
 }
 
 func (c *APIClient) doRequest(ctx context.Context, verb, requestPath string, body interface{}) ([]byte, int, error) {
@@ -30,7 +35,7 @@ func (c *APIClient) doRequest(ctx context.Context, verb, requestPath string, bod
 		return nil, 0, err
 	}
 
-	req, err := http.NewRequest("POST", c.URL+requestPath, bytes.NewBuffer(b))
+	req, err := http.NewRequest(verb, c.URL+requestPath, bytes.NewBuffer(b))
 	if err != nil {
 		return nil, 0, err
 	}

--- a/customerio.go
+++ b/customerio.go
@@ -39,24 +39,30 @@ func (e ParamError) Error() string { return e.Param + ": missing" }
 
 // NewTrackClient prepares a client for use with the Customer.io track API, see: https://customer.io/docs/api/#apitrackintroduction
 // using a Tracking Site ID and API Key pair from https://fly.customer.io/settings/api_credentials
-func NewTrackClient(siteID, apiKey string) *CustomerIO {
-	return NewCustomerIO(siteID, apiKey)
-}
-
-// NewCustomerIO prepares a client for use with the Customer.io track API, see: https://customer.io/docs/api/#apitrackintroduction
-// deprecated in favour of NewTrackClient
-func NewCustomerIO(siteID, apiKey string) *CustomerIO {
+func NewTrackClient(siteID, apiKey string, opts ...option) *CustomerIO {
 	client := &http.Client{
 		Transport: &http.Transport{
 			MaxIdleConnsPerHost: 100,
 		},
 	}
-	return &CustomerIO{
+	c := &CustomerIO{
 		siteID: siteID,
 		apiKey: apiKey,
 		URL:    "https://track.customer.io",
 		Client: client,
 	}
+
+	for _, opt := range opts {
+		opt.track(c)
+	}
+
+	return c
+}
+
+// NewCustomerIO prepares a client for use with the Customer.io track API, see: https://customer.io/docs/api/#apitrackintroduction
+// deprecated in favour of NewTrackClient
+func NewCustomerIO(siteID, apiKey string) *CustomerIO {
+	return NewTrackClient(siteID, apiKey)
 }
 
 // Identify identifies a customer and sets their attributes

--- a/examples/transactional.go
+++ b/examples/transactional.go
@@ -12,7 +12,7 @@ func main() {
 
 	ctx := context.Background()
 
-	client := customerio.NewAPIClient("<your-key-here>")
+	client := customerio.NewAPIClient("<your-key-here>", customerio.WithRegion(customerio.RegionUS))
 
 	req := customerio.SendEmailRequest{
 		Identifiers: map[string]string{

--- a/options.go
+++ b/options.go
@@ -1,0 +1,65 @@
+package customerio
+
+import "net/http"
+
+type option struct {
+	api   func(*APIClient)
+	track func(*CustomerIO)
+}
+
+type region int
+
+const (
+	Region_US region = 0
+	Region_EU region = 1
+
+	apiURL_US = "https://api.customer.io"
+	apiURL_EU = "https://api-eu.customer.io"
+
+	trackURL_US = "https://track.customer.io"
+	trackURL_EU = "https://track-eu.customer.io"
+)
+
+func WithRegion(r region) option {
+	return option{
+		api: func(a *APIClient) {
+			switch r {
+			case Region_US:
+				a.URL = apiURL_US
+			case Region_EU:
+				a.URL = apiURL_EU
+			}
+		},
+		track: func(c *CustomerIO) {
+			switch r {
+			case Region_US:
+				c.URL = trackURL_US
+			case Region_EU:
+				c.URL = trackURL_EU
+			}
+		},
+	}
+}
+
+func WithHTTPClient(client *http.Client) option {
+	return option{
+		api: func(a *APIClient) {
+			a.Client = client
+		},
+		track: func(c *CustomerIO) {
+			c.Client = client
+		},
+	}
+}
+
+// WithURL
+func WithURL(url string) option {
+	return option{
+		api: func(a *APIClient) {
+			a.URL = url
+		},
+		track: func(c *CustomerIO) {
+			c.URL = url
+		},
+	}
+}

--- a/options.go
+++ b/options.go
@@ -7,36 +7,29 @@ type option struct {
 	track func(*CustomerIO)
 }
 
-type region int
+type region struct {
+	apiURL   string
+	trackURL string
+}
 
-const (
-	Region_US region = 0
-	Region_EU region = 1
-
-	apiURL_US = "https://api.customer.io"
-	apiURL_EU = "https://api-eu.customer.io"
-
-	trackURL_US = "https://track.customer.io"
-	trackURL_EU = "https://track-eu.customer.io"
+var (
+	RegionUS = region{
+		apiURL:   "https://api.customer.io",
+		trackURL: "https://track.customer.io",
+	}
+	RegionEU = region{
+		apiURL:   "https://api-eu.customer.io",
+		trackURL: "https://track-eu.customer.io",
+	}
 )
 
 func WithRegion(r region) option {
 	return option{
 		api: func(a *APIClient) {
-			switch r {
-			case Region_US:
-				a.URL = apiURL_US
-			case Region_EU:
-				a.URL = apiURL_EU
-			}
+			a.URL = r.apiURL
 		},
 		track: func(c *CustomerIO) {
-			switch r {
-			case Region_US:
-				c.URL = trackURL_US
-			case Region_EU:
-				c.URL = trackURL_EU
-			}
+			c.URL = r.trackURL
 		},
 	}
 }
@@ -48,18 +41,6 @@ func WithHTTPClient(client *http.Client) option {
 		},
 		track: func(c *CustomerIO) {
 			c.Client = client
-		},
-	}
-}
-
-// WithURL
-func WithURL(url string) option {
-	return option{
-		api: func(a *APIClient) {
-			a.URL = url
-		},
-		track: func(c *CustomerIO) {
-			c.URL = url
 		},
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,65 @@
+package customerio
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestAPIOptions(t *testing.T) {
+
+	client := NewAPIClient("mykey")
+	if client.URL != apiURL_US {
+		t.Errorf("wrong default url. got: %s, want: %s", client.URL, apiURL_US)
+	}
+
+	client = NewAPIClient("mykey", WithURL("http://example.com"))
+	if client.URL != "http://example.com" {
+		t.Errorf("wrong url. got: %s, want: http://example.com", client.URL)
+	}
+
+	client = NewAPIClient("mykey", WithRegion(Region_EU))
+	if client.URL != apiURL_EU {
+		t.Errorf("wrong url. got: %s, want: %s", client.URL, apiURL_EU)
+	}
+
+	hc := &http.Client{}
+	client = NewAPIClient("mykey", WithHTTPClient(hc))
+	if !reflect.DeepEqual(client.Client, hc) {
+		t.Errorf("wrong http client. got: %#v, want: %#v", client.Client, hc)
+	}
+
+	client = NewAPIClient("mykey", WithURL("http://example.com"), WithRegion(Region_EU))
+	if client.URL != apiURL_EU {
+		t.Errorf("wrong url. got: %s, want: %s", client.URL, apiURL_EU)
+	}
+}
+
+func TestTrackOptions(t *testing.T) {
+
+	client := NewTrackClient("site_id", "api_key")
+	if client.URL != trackURL_US {
+		t.Errorf("wrong default url. got: %s, want: %s", client.URL, trackURL_US)
+	}
+
+	client = NewTrackClient("site_id", "api_key", WithURL("http://example.com"))
+	if client.URL != "http://example.com" {
+		t.Errorf("wrong url. got: %s, want: http://example.com", client.URL)
+	}
+
+	client = NewTrackClient("site_id", "api_key", WithRegion(Region_EU))
+	if client.URL != trackURL_EU {
+		t.Errorf("wrong url. got: %s, want: %s", client.URL, trackURL_EU)
+	}
+
+	hc := &http.Client{}
+	client = NewTrackClient("site_id", "api_key", WithHTTPClient(hc))
+	if !reflect.DeepEqual(client.Client, hc) {
+		t.Errorf("wrong http client. got: %#v, want: %#v", client.Client, hc)
+	}
+
+	client = NewTrackClient("site_id", "api_key", WithURL("http://example.com"), WithRegion(Region_EU))
+	if client.URL != trackURL_EU {
+		t.Errorf("wrong url. got: %s, want: %s", client.URL, trackURL_EU)
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -9,18 +9,13 @@ import (
 func TestAPIOptions(t *testing.T) {
 
 	client := NewAPIClient("mykey")
-	if client.URL != apiURL_US {
-		t.Errorf("wrong default url. got: %s, want: %s", client.URL, apiURL_US)
+	if client.URL != RegionUS.apiURL {
+		t.Errorf("wrong default url. got: %s, want: %s", client.URL, RegionUS.apiURL)
 	}
 
-	client = NewAPIClient("mykey", WithURL("http://example.com"))
-	if client.URL != "http://example.com" {
-		t.Errorf("wrong url. got: %s, want: http://example.com", client.URL)
-	}
-
-	client = NewAPIClient("mykey", WithRegion(Region_EU))
-	if client.URL != apiURL_EU {
-		t.Errorf("wrong url. got: %s, want: %s", client.URL, apiURL_EU)
+	client = NewAPIClient("mykey", WithRegion(RegionEU))
+	if client.URL != RegionEU.apiURL {
+		t.Errorf("wrong url. got: %s, want: %s", client.URL, RegionEU.apiURL)
 	}
 
 	hc := &http.Client{}
@@ -28,38 +23,23 @@ func TestAPIOptions(t *testing.T) {
 	if !reflect.DeepEqual(client.Client, hc) {
 		t.Errorf("wrong http client. got: %#v, want: %#v", client.Client, hc)
 	}
-
-	client = NewAPIClient("mykey", WithURL("http://example.com"), WithRegion(Region_EU))
-	if client.URL != apiURL_EU {
-		t.Errorf("wrong url. got: %s, want: %s", client.URL, apiURL_EU)
-	}
 }
 
 func TestTrackOptions(t *testing.T) {
 
 	client := NewTrackClient("site_id", "api_key")
-	if client.URL != trackURL_US {
-		t.Errorf("wrong default url. got: %s, want: %s", client.URL, trackURL_US)
+	if client.URL != RegionUS.trackURL {
+		t.Errorf("wrong default url. got: %s, want: %s", client.URL, RegionUS.trackURL)
 	}
 
-	client = NewTrackClient("site_id", "api_key", WithURL("http://example.com"))
-	if client.URL != "http://example.com" {
-		t.Errorf("wrong url. got: %s, want: http://example.com", client.URL)
-	}
-
-	client = NewTrackClient("site_id", "api_key", WithRegion(Region_EU))
-	if client.URL != trackURL_EU {
-		t.Errorf("wrong url. got: %s, want: %s", client.URL, trackURL_EU)
+	client = NewTrackClient("site_id", "api_key", WithRegion(RegionEU))
+	if client.URL != RegionEU.trackURL {
+		t.Errorf("wrong url. got: %s, want: %s", client.URL, RegionEU.trackURL)
 	}
 
 	hc := &http.Client{}
 	client = NewTrackClient("site_id", "api_key", WithHTTPClient(hc))
 	if !reflect.DeepEqual(client.Client, hc) {
 		t.Errorf("wrong http client. got: %#v, want: %#v", client.Client, hc)
-	}
-
-	client = NewTrackClient("site_id", "api_key", WithURL("http://example.com"), WithRegion(Region_EU))
-	if client.URL != trackURL_EU {
-		t.Errorf("wrong url. got: %s, want: %s", client.URL, trackURL_EU)
 	}
 }


### PR DESCRIPTION
Adds support for passing in a region which will update the API endpoints for both the Track and API clients, and adds funcopts to configure the clients (also adds `WithHTTPClient` for customizing the underlying *http.Client)

usage:
```
api := customerio.NewAPIClient(key, customerio.WithRegion(customerio.RegionEU))
track := customerio.NewTrackClient("site_id", "api_key", customerio.WithRegion(customerio.RegionEU))
```
(region defaults to `RegionUS` but can be set explicitly)