### PR TITLE
Upgrade to /v2 Go module

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,14 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.15', '1.16' ]
+        go: [ '1.15', '1.16.4' ]
     env:
       TEST_RESULTS: /tmp/test-results
     name: Go ${{ matrix.go }} test
     steps:
       - uses: actions/checkout@v2
-        with:
-          path: src/github.com/customerio/go-customerio
       - name: setup go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,5 +25,4 @@ jobs:
         run: |
           curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v0.6.0/gotestsum_0.6.0_linux_amd64.tar.gz" | sudo tar -xz -C /usr/local/bin gotestsum
       - run: | 
-          export GOPATH="${GOPATH}:${GITHUB_WORKSPACE}"
           gotestsum --junitfile ${TEST_RESULTS}/unit-tests.xml -- -timeout 5m -p 1 ./...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.15', '1.16.4' ]
+        go: [ '1.15', '1.16' ]
     env:
       TEST_RESULTS: /tmp/test-results
     name: Go ${{ matrix.go }} test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.10', '1.11', '1.12' ]
+        go: [ '1.15', '1.16' ]
     env:
       TEST_RESULTS: /tmp/test-results
     name: Go ${{ matrix.go }} test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## March 24, 2021
+## June 16, 2021 v2.2.0
+
+### Added
+- Modules support
+- Updated license date
+- Upgraded version support
+
+## March 24, 2021 v2.1.0
 ### Added
 - Support for EU region
 - Allow using custom `*http.Client`
@@ -8,7 +15,7 @@
 ### Changed
 - `customerio.NewAPIClient` and `customerio.NewTrackClient`  have a new variadic parameter for options in order to choose US/EU region and/or customer HTTP client.
 
-## December 3, 2020
+## December 3, 2020 v2.0.0
 ### Added
 - Support for transactional api
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Customer IO
+Copyright (c) 2021 Customer IO
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # go-customerio [![CircleCI](https://circleci.com/gh/customerio/go-customerio/tree/master.svg?style=svg)](https://circleci.com/gh/customerio/go-customerio/tree/master)
 
 A golang client for the [Customer.io](http://customer.io) [event API](https://app.customer.io/api/docs/index.html).
-_Tested with Go1.12_
+_Tested with Go1.16_
 
 Godoc here: [https://godoc.org/github.com/customerio/go-customerio](https://godoc.org/github.com/customerio/go-customerio)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this line to your application's imports:
 ```go
 import (
     // ...
-    "github.com/customerio/go-customerio"
+    "github.com/customerio/go-customerio/v2"
 )
 ```
 
@@ -24,7 +24,7 @@ And then execute:
 
 Or install it yourself:
 
-    $ go get "github.com/customerio/go-customerio"
+    $ go get github.com/customerio/go-customerio
 
 ## Usage
 

--- a/customerio_test.go
+++ b/customerio_test.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/customerio/go-customerio"
+	"github.com/customerio/go-customerio/v2"
 )
 
 var cio *customerio.CustomerIO

--- a/examples/transactional.go
+++ b/examples/transactional.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/customerio/go-customerio"
+	"github.com/customerio/go-customerio/v2"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/customerio/go-customerio
+module github.com/customerio/go-customerio/v2
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/customerio/go-customerio
+
+go 1.16

--- a/options.go
+++ b/options.go
@@ -8,28 +8,28 @@ type option struct {
 }
 
 type region struct {
-	apiURL   string
-	trackURL string
+	ApiURL   string
+	TrackURL string
 }
 
 var (
 	RegionUS = region{
-		apiURL:   "https://api.customer.io",
-		trackURL: "https://track.customer.io",
+		ApiURL:   "https://api.customer.io",
+		TrackURL: "https://track.customer.io",
 	}
 	RegionEU = region{
-		apiURL:   "https://api-eu.customer.io",
-		trackURL: "https://track-eu.customer.io",
+		ApiURL:   "https://api-eu.customer.io",
+		TrackURL: "https://track-eu.customer.io",
 	}
 )
 
 func WithRegion(r region) option {
 	return option{
 		api: func(a *APIClient) {
-			a.URL = r.apiURL
+			a.URL = r.ApiURL
 		},
 		track: func(c *CustomerIO) {
-			c.URL = r.trackURL
+			c.URL = r.TrackURL
 		},
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/customerio/go-customerio"
+	"github.com/customerio/go-customerio/v2"
 )
 
 func TestAPIOptions(t *testing.T) {

--- a/options_test.go
+++ b/options_test.go
@@ -1,25 +1,27 @@
-package customerio
+package customerio_test
 
 import (
 	"net/http"
 	"reflect"
 	"testing"
+
+	"github.com/customerio/go-customerio"
 )
 
 func TestAPIOptions(t *testing.T) {
 
-	client := NewAPIClient("mykey")
-	if client.URL != RegionUS.apiURL {
-		t.Errorf("wrong default url. got: %s, want: %s", client.URL, RegionUS.apiURL)
+	client := customerio.NewAPIClient("mykey")
+	if client.URL != customerio.RegionUS.ApiURL {
+		t.Errorf("wrong default url. got: %s, want: %s", client.URL, customerio.RegionUS.ApiURL)
 	}
 
-	client = NewAPIClient("mykey", WithRegion(RegionEU))
-	if client.URL != RegionEU.apiURL {
-		t.Errorf("wrong url. got: %s, want: %s", client.URL, RegionEU.apiURL)
+	client = customerio.NewAPIClient("mykey", customerio.WithRegion(customerio.RegionEU))
+	if client.URL != customerio.RegionEU.ApiURL {
+		t.Errorf("wrong url. got: %s, want: %s", client.URL, customerio.RegionEU.ApiURL)
 	}
 
 	hc := &http.Client{}
-	client = NewAPIClient("mykey", WithHTTPClient(hc))
+	client = customerio.NewAPIClient("mykey", customerio.WithHTTPClient(hc))
 	if !reflect.DeepEqual(client.Client, hc) {
 		t.Errorf("wrong http client. got: %#v, want: %#v", client.Client, hc)
 	}
@@ -27,18 +29,18 @@ func TestAPIOptions(t *testing.T) {
 
 func TestTrackOptions(t *testing.T) {
 
-	client := NewTrackClient("site_id", "api_key")
-	if client.URL != RegionUS.trackURL {
-		t.Errorf("wrong default url. got: %s, want: %s", client.URL, RegionUS.trackURL)
+	client := customerio.NewTrackClient("site_id", "api_key")
+	if client.URL != customerio.RegionUS.TrackURL {
+		t.Errorf("wrong default url. got: %s, want: %s", client.URL, customerio.RegionUS.TrackURL)
 	}
 
-	client = NewTrackClient("site_id", "api_key", WithRegion(RegionEU))
-	if client.URL != RegionEU.trackURL {
-		t.Errorf("wrong url. got: %s, want: %s", client.URL, RegionEU.trackURL)
+	client = customerio.NewTrackClient("site_id", "api_key", customerio.WithRegion(customerio.RegionEU))
+	if client.URL != customerio.RegionEU.TrackURL {
+		t.Errorf("wrong url. got: %s, want: %s", client.URL, customerio.RegionEU.TrackURL)
 	}
 
 	hc := &http.Client{}
-	client = NewTrackClient("site_id", "api_key", WithHTTPClient(hc))
+	client = customerio.NewTrackClient("site_id", "api_key", customerio.WithHTTPClient(hc))
 	if !reflect.DeepEqual(client.Client, hc) {
 		t.Errorf("wrong http client. got: %#v, want: %#v", client.Client, hc)
 	}

--- a/send_email_test.go
+++ b/send_email_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/customerio/go-customerio"
+	"github.com/customerio/go-customerio/v2"
 )
 
 func TestSendEmail(t *testing.T) {


### PR DESCRIPTION
Proper v2 release of `go-customerio` using module pathing