### PR TITLE
Add support for anonymous events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## July 6, 2021 v3.0.0
+### Changed
+- `trackAnonymous` now requires an `anonymous_id` parameter and will no longer trigger campaigns. If you previously used anonymous events to trigger campaigns, you can still do so [directly through the API](https://customer.io/docs/api/#operation/trackAnonymous). We now refer to anonymous events that trigger campaigns as ["invite events"](https://customer.io/docs/anonymous-events/#anonymous-or-invite). 
+
 ## June 16, 2021 v2.2.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -133,19 +133,17 @@ track.Track("5", "purchase", map[string]interface{}{
 
 ### Tracking an anonymous event
 
-[Anonymous
-events](https://learn.customer.io/recipes/anonymous-invite-emails.html) are
-also supported. These are ideal for when you need to track an event for a
-customer which may not exist in your People list.
+You can also send anonymous events representing people you haven't identified. An anonymous event requires an `anonymous_id` representing the unknown person and an event `name`. When you identify a person, you can set their `anonymous_id` attribute. If [event merging](https://customer.io/docs/anonymous-events/#turn-on-merging) is turned on in your workspace, and the attribute matches the `anonymous_id` in one or more events that were logged within the last 30 days, we associate those events with the person.
 
 ```go
 // Arguments
+// anonymous_id (required)    - an identifier representing an unknown person.
 // name (required)            - the name of the event you want to track.
 // attributes (optional)      - any related information you'd like to attach to this
 //                              event, as a ```map[string]interface{}```. These attributes can be used in your triggers to control who should
 //                              receive the triggered email. You can set any number of data values.
 
-track.TrackAnonymous("invite", map[string]interface{}{
+track.TrackAnonymous("anonymous_id", "invite", map[string]interface{}{
     "first_name": "Alex",
     "source": "OldApp",
 })

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this line to your application's imports:
 ```go
 import (
     // ...
-    "github.com/customerio/go-customerio/v2"
+    "github.com/customerio/go-customerio/v3"
 )
 ```
 

--- a/customerio.go
+++ b/customerio.go
@@ -92,15 +92,19 @@ func (c *CustomerIO) Track(customerID string, eventName string, data map[string]
 }
 
 // TrackAnonymous sends a single event to Customer.io for the anonymous user
-func (c *CustomerIO) TrackAnonymous(eventName string, data map[string]interface{}) error {
+func (c *CustomerIO) TrackAnonymous(anonymousID, eventName string, data map[string]interface{}) error {
+	if anonymousID == "" {
+		return ParamError{Param: "anonymousID"}
+	}
 	if eventName == "" {
 		return ParamError{Param: "eventName"}
 	}
 	return c.request("POST",
 		fmt.Sprintf("%s/api/v1/events", c.URL),
 		map[string]interface{}{
-			"name": eventName,
-			"data": data,
+			"name":         eventName,
+			"anonymous_id": anonymousID,
+			"data":         data,
 		})
 }
 

--- a/customerio_test.go
+++ b/customerio_test.go
@@ -110,14 +110,15 @@ func TestTrackAnonymous(t *testing.T) {
 	}
 
 	body := map[string]interface{}{
-		"name": "test",
+		"name":         "test",
+		"anonymous_id": "anon123",
 		"data": map[string]interface{}{
 			"a": "1",
 		},
 	}
 
 	expect("POST", "/api/v1/events", body)
-	if err := cio.TrackAnonymous("test", data); err != nil {
+	if err := cio.TrackAnonymous("anon123", "test", data); err != nil {
 		t.Error(err.Error())
 	}
 }

--- a/customerio_test.go
+++ b/customerio_test.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/customerio/go-customerio/v2"
+	"github.com/customerio/go-customerio/v3"
 )
 
 var cio *customerio.CustomerIO

--- a/examples/transactional.go
+++ b/examples/transactional.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/customerio/go-customerio/v2"
+	"github.com/customerio/go-customerio/v3"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/customerio/go-customerio/v2
+module github.com/customerio/go-customerio/v3
 
 go 1.16

--- a/options_test.go
+++ b/options_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/customerio/go-customerio/v2"
+	"github.com/customerio/go-customerio/v3"
 )
 
 func TestAPIOptions(t *testing.T) {

--- a/send_email_test.go
+++ b/send_email_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/customerio/go-customerio/v2"
+	"github.com/customerio/go-customerio/v3"
 )
 
 func TestSendEmail(t *testing.T) {


### PR DESCRIPTION
This PR adds support for sending anonymous events. These anonymous events can later be associated / identified with an existing customer. It'll be a breaking change as we're replacing the old `TrackAnonymous` method.

###### Usage

```
track.TrackAnonymous(anonymous_id, "test_event", { ... })
```

We don't generate anonymous IDs. The user has to generate them and pass them to the `TrackAnonymous` method. This needs updates to documentation and changelog before merging.