### PR TITLE
Add ability to set User-Agent

### DIFF
--- a/api.go
+++ b/api.go
@@ -22,7 +22,7 @@ func NewAPIClient(key string, opts ...option) *APIClient {
 		Key:       key,
 		Client:    http.DefaultClient,
 		URL:       "https://api.customer.io",
-		UserAgent: "Customer.io Go Client/3.0",
+		UserAgent: DefaultUserAgent,
 	}
 
 	for _, opt := range opts {

--- a/api.go
+++ b/api.go
@@ -9,18 +9,20 @@ import (
 )
 
 type APIClient struct {
-	Key    string
-	URL    string
-	Client *http.Client
+	Key       string
+	URL       string
+	UserAgent string
+	Client    *http.Client
 }
 
 // NewAPIClient prepares a client for use with the Customer.io API, see: https://customer.io/docs/api/#apicoreintroduction
 // using an App API Key from https://fly.customer.io/settings/api_credentials?keyType=app
 func NewAPIClient(key string, opts ...option) *APIClient {
 	client := &APIClient{
-		Key:    key,
-		Client: http.DefaultClient,
-		URL:    "https://api.customer.io",
+		Key:       key,
+		Client:    http.DefaultClient,
+		URL:       "https://api.customer.io",
+		UserAgent: "Customer.io Go Client/3.0",
 	}
 
 	for _, opt := range opts {
@@ -44,7 +46,7 @@ func (c *APIClient) doRequest(ctx context.Context, verb, requestPath string, bod
 
 	req.Header.Set("Authorization", "Bearer "+c.Key)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Add("User-Agent", "Customer.io Go Client/3.0")
+	req.Header.Add("User-Agent", c.UserAgent)
 
 	resp, err := c.Client.Do(req)
 	if err != nil {

--- a/api.go
+++ b/api.go
@@ -44,6 +44,7 @@ func (c *APIClient) doRequest(ctx context.Context, verb, requestPath string, bod
 
 	req.Header.Set("Authorization", "Bearer "+c.Key)
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Add("User-Agent", "Customer.io Go Client/3.0")
 
 	resp, err := c.Client.Do(req)
 	if err != nil {

--- a/customerio.go
+++ b/customerio.go
@@ -176,6 +176,7 @@ func (c *CustomerIO) request(method, url string, body interface{}) error {
 			return err
 		}
 
+		req.Header.Add("User-Agent", "Customer.io Go Client/3.0")
 		req.Header.Add("Content-Type", "application/json")
 		req.Header.Add("Content-Length", strconv.Itoa(len(j)))
 	} else {

--- a/customerio.go
+++ b/customerio.go
@@ -54,7 +54,7 @@ func NewTrackClient(siteID, apiKey string, opts ...option) *CustomerIO {
 		siteID:    siteID,
 		apiKey:    apiKey,
 		URL:       "https://track.customer.io",
-		UserAgent: "Customer.io Go Client/3.0",
+		UserAgent: DefaultUserAgent,
 		Client:    client,
 	}
 

--- a/customerio.go
+++ b/customerio.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 )
 
+const DefaultUserAgent = "Customer.io Go Client/" + Version
+
 // CustomerIO wraps the customer.io track API, see: https://customer.io/docs/api/#apitrackintroduction
 type CustomerIO struct {
 	siteID    string

--- a/customerio.go
+++ b/customerio.go
@@ -15,10 +15,11 @@ import (
 
 // CustomerIO wraps the customer.io track API, see: https://customer.io/docs/api/#apitrackintroduction
 type CustomerIO struct {
-	siteID string
-	apiKey string
-	URL    string
-	Client *http.Client
+	siteID    string
+	apiKey    string
+	URL       string
+	UserAgent string
+	Client    *http.Client
 }
 
 // CustomerIOError is returned by any method that fails at the API level
@@ -48,10 +49,11 @@ func NewTrackClient(siteID, apiKey string, opts ...option) *CustomerIO {
 		},
 	}
 	c := &CustomerIO{
-		siteID: siteID,
-		apiKey: apiKey,
-		URL:    "https://track.customer.io",
-		Client: client,
+		siteID:    siteID,
+		apiKey:    apiKey,
+		URL:       "https://track.customer.io",
+		UserAgent: "Customer.io Go Client/3.0",
+		Client:    client,
 	}
 
 	for _, opt := range opts {
@@ -176,7 +178,7 @@ func (c *CustomerIO) request(method, url string, body interface{}) error {
 			return err
 		}
 
-		req.Header.Add("User-Agent", "Customer.io Go Client/3.0")
+		req.Header.Add("User-Agent", c.UserAgent)
 		req.Header.Add("Content-Type", "application/json")
 		req.Header.Add("Content-Length", strconv.Itoa(len(j)))
 	} else {

--- a/options.go
+++ b/options.go
@@ -45,7 +45,7 @@ func WithHTTPClient(client *http.Client) option {
 	}
 }
 
-func WithCustomUserAgent(ua string) option {
+func WithUserAgent(ua string) option {
 	return option{
 		api: func(a *APIClient) {
 			a.UserAgent = ua

--- a/options.go
+++ b/options.go
@@ -44,3 +44,14 @@ func WithHTTPClient(client *http.Client) option {
 		},
 	}
 }
+
+func WithCustomUserAgent(ua string) option {
+	return option{
+		api: func(a *APIClient) {
+			a.UserAgent = ua
+		},
+		track: func(c *CustomerIO) {
+			c.UserAgent = ua
+		},
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -27,7 +27,7 @@ func TestAPIOptions(t *testing.T) {
 	}
 
 	customUserAgent := "Customer.io"
-	client = customerio.NewAPIClient("mykey", customerio.WithCustomUserAgent(customUserAgent))
+	client = customerio.NewAPIClient("mykey", customerio.WithUserAgent(customUserAgent))
 	if client.UserAgent != customUserAgent {
 		t.Errorf("wrong user-agent. got: %s, want: %s", client.UserAgent, customUserAgent)
 	}
@@ -49,5 +49,11 @@ func TestTrackOptions(t *testing.T) {
 	client = customerio.NewTrackClient("site_id", "api_key", customerio.WithHTTPClient(hc))
 	if !reflect.DeepEqual(client.Client, hc) {
 		t.Errorf("wrong http client. got: %#v, want: %#v", client.Client, hc)
+	}
+
+	customUserAgent := "Customer.io"
+	client = customerio.NewTrackClient("site_id", "api_key", customerio.WithUserAgent(customUserAgent))
+	if client.UserAgent != customUserAgent {
+		t.Errorf("wrong user-agent. got: %s, want: %s", client.UserAgent, customUserAgent)
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -25,6 +25,12 @@ func TestAPIOptions(t *testing.T) {
 	if !reflect.DeepEqual(client.Client, hc) {
 		t.Errorf("wrong http client. got: %#v, want: %#v", client.Client, hc)
 	}
+
+	customUserAgent := "Customer.io"
+	client = customerio.NewAPIClient("mykey", customerio.WithCustomUserAgent(customUserAgent))
+	if client.UserAgent != customUserAgent {
+		t.Errorf("wrong user-agent. got: %s, want: %s", client.UserAgent, customUserAgent)
+	}
 }
 
 func TestTrackOptions(t *testing.T) {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package customerio
 
-const Version = "3.1.0"
+const Version = "3.2.0"

--- a/version.go
+++ b/version.go
@@ -1,0 +1,3 @@
+package customerio
+
+const Version = "3.1.0"


### PR DESCRIPTION
Adds a default user agent of "Customer.io Go Client/3.0" on requests made with the client and the option to set a custom user agent option.

Related to: https://github.com/customerio/issues/issues/6159