### PR TITLE
update version so import matches installed version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ And then execute:
 
 Or install it yourself:
 
-    $ go get github.com/customerio/go-customerio
+    $ go get github.com/customerio/go-customerio/v3
 
 ## Usage
 


### PR DESCRIPTION
Following readme does not work out of the box.
A specific version is needed on the go get command.