### PR TITLE
docs: add customer.io brand header to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
-# Customerio
+<p align="center">
+  <a href="https://customer.io">
+    <img src="https://user-images.githubusercontent.com/6409227/144680509-907ee093-d7ad-4a9c-b0a5-f640eeb060cd.png" height="60">
+  </a>
+  <p align="center">Power automated communication that people like to receive.</p>
+</p>
 
-# go-customerio [![CircleCI](https://circleci.com/gh/customerio/go-customerio/tree/master.svg?style=svg)](https://circleci.com/gh/customerio/go-customerio/tree/master)
+![Latest release](https://img.shields.io/github/v/release/customerio/go-customerio)
+![Software License](https://img.shields.io/github/license/customerio/go-customerio)
+[![Build status](https://github.com/customerio/go-customerio/actions/workflows/main.yml/badge.svg)](https://github.com/customerio/go-customerio/actions/workflows/main.yml)
+![Go version](https://img.shields.io/github/go-mod/go-version/customerio/go-customerio)
+[![Go Doc](https://img.shields.io/badge/Go_Doc-reference-blue.svg)](https://pkg.go.dev/github.com/customerio/go-customerio/v3)
+
+# Customer.io Go 
 
 A golang client for the [Customer.io](http://customer.io) [event API](https://app.customer.io/api/docs/index.html).
 _Tested with Go1.16_
-
-Godoc here: [https://godoc.org/github.com/customerio/go-customerio](https://godoc.org/github.com/customerio/go-customerio)
 
 ## Installation
 


### PR DESCRIPTION
This PR updates the README for our Go client library to include our brand logo and mission similar to how we have on language specific integration libraries like https://github.com/customerio/customerio-ruby#readme

Let me know if there's any questions or suggestions!