### PR TITLE
chore: housekeeping updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,6 @@ jobs:
     strategy:
       matrix:
         go: [  '1.15.x', '1.16.x', '1.17.x', 'tip' ]
-    env:
-      TEST_RESULTS: /tmp/test-results
     name: Go ${{ matrix.go }} test
     steps:
       - uses: actions/checkout@v2
@@ -26,9 +24,16 @@ jobs:
           tar -C ~/sdk/gotip -xzf gotip.tar.gz
           echo "PATH=$HOME/go/bin:$HOME/sdk/gotip/bin/:$PATH" >> $GITHUB_ENV
       - run: go version
-      - run: mkdir -pv $TEST_RESULTS
       - name: Setup gotestsum
         run: |
           curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v0.6.0/gotestsum_0.6.0_linux_amd64.tar.gz" | sudo tar -xz -C /usr/local/bin gotestsum
-      - run: | 
-          gotestsum --junitfile ${TEST_RESULTS}/unit-tests.xml -- -timeout 5m -p 1 ./...
+      - run: go test -race -coverprofile=coverage.txt -covermode=atomic
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v2
+        env:
+          GO_VERSION: ${{ matrix.go }}
+        with:
+          files: ./coverage.txt
+          env_vars: GO_VERSION
+          flags: unittests
+          fail_ci_if_error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,22 +1,30 @@
-name: build
+name: ci
 
 on: [ push ]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.15', '1.16' ]
+        go: [  '1.15.x', '1.16.x', '1.17.x', 'tip' ]
     env:
       TEST_RESULTS: /tmp/test-results
     name: Go ${{ matrix.go }} test
     steps:
       - uses: actions/checkout@v2
-      - name: setup go
+      - name: Install stable Go
+        if: matrix.go != 'tip'
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go }}
+      - name: Install Go tip
+        if: matrix.go == 'tip'
+        run: |
+          curl -sL https://storage.googleapis.com/go-build-snap/go/linux-amd64/$(git ls-remote https://github.com/golang/go.git HEAD | awk '{print $1;}').tar.gz -o gotip.tar.gz
+          mkdir -p ~/sdk/gotip
+          tar -C ~/sdk/gotip -xzf gotip.tar.gz
+          echo "PATH=$HOME/go/bin:$HOME/sdk/gotip/bin/:$PATH" >> $GITHUB_ENV
       - run: go env
       - run: mkdir -pv $TEST_RESULTS
       - name: Setup gotestsum

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
           mkdir -p ~/sdk/gotip
           tar -C ~/sdk/gotip -xzf gotip.tar.gz
           echo "PATH=$HOME/go/bin:$HOME/sdk/gotip/bin/:$PATH" >> $GITHUB_ENV
-      - run: go env
+      - run: go version
       - run: mkdir -pv $TEST_RESULTS
       - name: Setup gotestsum
         run: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+tasks:
+  - init: go mod download
+
+vscode:
+  extensions:
+    - golang.go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,33 @@
 # Changelog
 
-## July 6, 2021 v3.1.0
+## [v3.2.0](https://github.com/customerio/go-customerio/compare/v3.1.0...v.3.2.0) (2021-10-04)
+### Added
+- **client:** adds a default User-Agent header on requests and the option to set a custom User-Agent value. ([2123497](https://github.com/customerio/go-customerio/commit/212349768ba234d6c4ad3684aa6450f770f35cb8))
+
+## [v3.1.0](https://github.com/customerio/go-customerio/compare/3.0.0...v3.1.0) (2021-09-27)
 ### Added
 - Added new method to merge duplicate customers. More details in [API Documentation](https://customer.io/docs/api/#operation/merge)
 
-## July 6, 2021 v3.0.0
+## [v3.0.0](https://github.com/customerio/go-customerio/compare/v2.2.0...3.0.0) (2021-07-08)
 ### Changed
 - `trackAnonymous` now requires an `anonymous_id` parameter and will no longer trigger campaigns. If you previously used anonymous events to trigger campaigns, you can still do so [directly through the API](https://customer.io/docs/api/#operation/trackAnonymous). We now refer to anonymous events that trigger campaigns as ["invite events"](https://customer.io/docs/anonymous-events/#anonymous-or-invite). 
 
-## June 16, 2021 v2.2.0
+## [v2.2.0](https://github.com/customerio/go-customerio/compare/2.1.0...v2.2.0) (2021-06-17)
 
 ### Added
 - Modules support
 - Updated license date
 - Upgraded version support
 
-## March 24, 2021 v2.1.0
+## [v2.1.0](https://github.com/customerio/go-customerio/compare/v2.0.0...2.1.0) (2021-03-29)
 ### Added
 - Support for EU region
 - Allow using custom `*http.Client`
-### Removed
+
 ### Changed
 - `customerio.NewAPIClient` and `customerio.NewTrackClient`  have a new variadic parameter for options in order to choose US/EU region and/or customer HTTP client.
 
-## December 3, 2020 v2.0.0
+## [v2.0.0](https://github.com/customerio/go-customerio/compare/v1.2.0...v2.0.0) (2020-12-03)
 ### Added
 - Support for transactional api
 
@@ -35,3 +39,29 @@
 - Improved validations for required fields
 - Updated `CustomerIO` struct to use a URL field instead of separate Host and SSL fields
 - Improved test suite
+
+## [v1.2.0](https://github.com/customerio/go-customerio/compare/v1.1.0...v1.2.0) (2020-09-08)
+### Fixed
+- Read response body regardless of content length
+
+
+## [v1.1.0](https://github.com/customerio/go-customerio/compare/v1.0.0...v1.1.0) (2019-10-24)
+### Added
+- `TrackAnonymous` method
+- `AddDevice` and `DeleteDevice` methods
+- `AddCustomersToSegment` and `RemoveCustomersFromSegment` methods
+
+### Changed
+- Increase default client connection pool size to 100
+
+## [v1.0.0](https://github.com/customerio/go-customerio/compare/4a9e70a...v1.0.0) (2017-09-12)
+### Added
+- Initial API client library
+  - Create Identify call
+  - Create Track call
+  - Create Customer Delete call
+  - Test suite for API calls
+
+## [v0.0.0](https://github.com/customerio/go-customerio/commit/4a9e70a) (2015-01-12)
+### Added
+- Initial commit

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021 Customer IO
+Copyright (c) 2022 Customer IO
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@
 
 # Customer.io Go 
 
-A golang client for the [Customer.io](http://customer.io) [event API](https://app.customer.io/api/docs/index.html).
-_Tested with Go1.16_
+A Go client library for interacting with the [Customer.io API](https://customer.io/docs/api/).
 
 ## Installation
 
@@ -35,57 +34,113 @@ Or install it yourself:
 
     $ go get github.com/customerio/go-customerio
 
-## Usage
-
-### Before we get started: API client vs. JavaScript snippet
+## Before we get started: API client vs. JavaScript snippet
 
 It's helpful to know that everything below can also be accomplished
-through the [Customer.io JavaScript snippet](http://customer.io/docs/basic-integration.html).
+through the [Customer.io JavaScript snippet](https://customer.io/docs/basic-integration.html).
 
 In many cases, using the JavaScript snippet will be easier to integrate with
 your app, but there are several reasons why using the API client is useful:
 
 - You're not planning on triggering emails based on how customers interact with
   your website (e.g. users who haven't visited the site in X days)
-- You're using the javascript snippet, but have a few events you'd like to
+- You're using the JavaScript snippet, but have a few events you'd like to
   send from your backend system. They will work well together!
-- You'd rather not have another javascript snippet slowing down your frontend.
+- You'd rather not have another JavaScript snippet slowing down your frontend.
   Our snippet is asynchronous (doesn't affect initial page load) and very small, but we understand.
 
 In the end, the decision on whether or not to use the API client or
 the JavaScript snippet should be based on what works best for you.
-You'll be able to integrate **fully** with [Customer.io](http://customer.io) with either approach.
+You'll be able to integrate **fully** with [Customer.io](https://customer.io) with either approach.
 
-### Setup
+Create an instance of the Track API or App API client with your [Customer.io credentials](https://fly.customer.io/settings/api_credentials).
 
-Create an instance of the client with your [Customer.io credentials](https://fly.customer.io/settings/api_credentials).
+## Usage
 
 ```go
-track := customerio.NewTrackClient("YOUR SITE ID", "YOUR API SECRET KEY", customerio.WithRegion(customerio.RegionUS))
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/customerio/go-customerio/v3"
+)
+
+var (
+	// You can find or create new API credentials in your Customer.io
+	// account under "Account Settings" => "API Credentials":
+	// (https://fly.customer.io/settings/api_credentials)
+	siteID      string = "your-site-id"
+	trackAPIKey string = "your-track-api-key"
+	appAPIKey   string = "your-app-api-key"
+)
+
+func main() {
+	// Create an instance of the Customer.io Track API client
+	track := customerio.NewTrackClient(siteID, trackAPIKey, customerio.WithRegion(customerio.RegionUS))
+
+	// Send an Identify TrackAPI call
+	if err := track.Identify("5", map[string]interface{}{
+		"email":      "lucy@example.com",
+		"created_at": time.Now().Unix(),
+		"first_name": "Lucy",
+		"plan":       "basic",
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Create an instance of the Customer.io App API Client
+	cio := customerio.NewAPIClient(appAPIKey, customerio.WithRegion(customerio.RegionUS))
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	// The request object allows you to specify recipients and message data
+	request := customerio.SendEmailRequest{
+		Identifiers: map[string]string{
+			"id": "customer_1",
+		},
+		To:      "customer@example.com",
+		From:    "business@example.com",
+		Subject: "hello, {{ trigger.name }}",
+		Body:    "hello from the Customer.io {{ trigger.client }} client",
+		MessageData: map[string]interface{}{
+			"client": "Go",
+			"name":   "gopher",
+		},
+	}
+
+	// Send the email with a 10 second timeout
+	resp, err := cio.SendEmail(ctx, &request)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Resp: %s\n", resp)
+}
+
 ```
 
-Your account region—`RegionUS` or `RegionEU`—is optional. If you do not specify your region, we assume that your account is based in the US (`RegionUS`). If your account is based in the EU and you do not provide the correct region, we'll route requests from the US to `RegionEU` accordingly, however this may cause data to be logged in the US. 
+Your account region (`customerio.RegionUS` or `customerio.RegionEU`) is optional. If you do not specify your region, we assume that your account is based in the US (`customerio.RegionUS`). 
+
+If your account is based in the EU and you do not provide the correct region, we'll route requests from the US to `customerio.RegionEU` accordingly, however this may cause data to be logged in the US. 
 
 ### Identify logged in customers
 
-Tracking data of logged in customers is a key part of [Customer.io](http://customer.io). In order to
-send triggered emails, we must know the email address of the customer. You can
-also specify any number of customer attributes which help tailor [Customer.io](http://customer.io) to your
-business.
+Tracking data of logged in customers is a key part of [Customer.io](https://customer.io). In order to send triggered messages, we must know the email address of the customer to send email or the phone number for SMS.
+
+You can also specify any number of customer attributes which help tailor [Customer.io](https://customer.io) to your business.
 
 Attributes you specify are useful in several ways:
 
-- As customer variables in your triggered emails. For instance, if you specify
-  the customer's name, you can personalize the triggered email by using it in the
-  subject or body.
+- As customer variables in your triggered messages. For instance, if you specify the customer's name, you can personalize the triggered message by using it in the subject or body.
 
-- As a way to filter who should receive a triggered email. For instance,
-  if you pass along the current subscription plan (free / basic / premium) for your customers, you can
-  set up triggers which are only sent to customers who have subscribed to a
-  particular plan (e.g. "premium").
+- As a way to filter who should receive a triggered message. For instance, if you pass along the current subscription plan (free / basic / premium) for your customers, you can set up triggers which are only sent to customers who have subscribed to a particular plan (e.g. "premium").
 
-You'll want to identify your customers when they sign up for your app and any time their
-key information changes. This keeps [Customer.io](http://customer.io) up to date with your customer information.
+You'll want to identify your customers when they sign up for your product and any time their key information changes. This keeps [Customer.io](https://customer.io) up to date with your customer information.
 
 ```go
 // Arguments
@@ -93,14 +148,16 @@ key information changes. This keeps [Customer.io](http://customer.io) up to date
 // attributes (required) - a ```map[string]interface{}``` of information about the customer. You can pass any
 //                         information that would be useful in your triggers. You
 //                         should at least pass in an email, and created_at timestamp.
-//                         your interface{} should be parseable as Json by 'encoding/json'.Marshal
+//                         your interface{} should be parseable as JSON by 'encoding/json'.Marshal
 
-track.Identify("5", map[string]interface{}{
+if err := track.Identify("5", map[string]interface{}{
   "email": "bob@example.com",
   "created_at": time.Now().Unix(),
   "first_name": "Bob",
   "plan": "basic",
-})
+}); err != nil {
+  // handle error
+}
 ```
 
 ### Deleting customers
@@ -116,38 +173,44 @@ recreated.
 //                          should be the same id you'd pass into the
 //                          `identify` command above.
 
-track.Delete("5")
+if err := track.Delete("5"); err != nil {
+  // handle error
+}
 ```
 
 ### Merge Duplicate Customers
 
-When you merge two people, you pick a primary person and merge a secondary, duplicate person into it. The primary person remains after the merge and the secondary is deleted. This process is permanent: you cannot recover the secondary person.
+When you merge two people, you pick a primary person and merge a secondary, duplicate person into the primary person. The primary person remains after the merge and the secondary person is deleted. This process is permanent: you cannot recover the secondary person.
 
-The first and third parameters represent the identifier for the primary and secondary people respectively—one of `id`, `email`, or `cio_id`. The second and fourth parameters are the identifier values for the primary and secondary people, respectively.
+The first and third parameters represent the identifier for the primary and secondary people respectively, one of `id`, `email`, or `cio_id`. The second and fourth parameters are the identifier values for the primary and secondary people, respectively.
 
 ```go
-track.MergeCustomers(customerio.IdentifierTypeEmail, "cool.person@company.com", customerio.IdentifierTypeCioID, "C123")
+if err := track.MergeCustomers(customerio.IdentifierTypeEmail, "cool.person@company.com", customerio.IdentifierTypeCioID, "C123"); err != nil {
+  // handle error
+}
 ```
 
 ### Tracking a custom event
 
-Now that you're identifying your customers with [Customer.io](http://customer.io), you can now send events like
-"purchased" or "watchedIntroVideo". These allow you to more specifically target your users
-with automated emails, and track conversions when you're sending automated emails to
-encourage your customers to perform an action.
+Now that you're identifying your customers with [Customer.io](https://customer.io), you can now send events like "purchased" or "watchedIntroVideo". 
+
+These allow you to more specifically target your users with automated messages, and track conversions when you're sending automated messages to encourage your customers to perform an action.
 
 ```go
 // Arguments
 // customerID (required)  - the id of the customer who you want to associate with the event.
 // name (required)        - the name of the event you want to track.
 // attributes (optional)  - any related information you'd like to attach to this
-//                          event, as a ```map[string]interface{}```. These attributes can be used in your triggers to control who should
-//                         receive the triggered email. You can set any number of data values.
+//                          event, as a ```map[string]interface{}```. 
+//                          These attributes can be used in your triggers to control who should
+//                          receive the triggered message. You can set any number of data values.
 
-track.Track("5", "purchase", map[string]interface{}{
+if err := track.Track("5", "purchase", map[string]interface{}{
     "type": "socks",
     "price": "13.99",
-})
+}); err != nil {
+  // handle error
+}
 ```
 
 ### Tracking an anonymous event
@@ -159,13 +222,16 @@ You can also send anonymous events representing people you haven't identified. A
 // anonymous_id (required)    - an identifier representing an unknown person.
 // name (required)            - the name of the event you want to track.
 // attributes (optional)      - any related information you'd like to attach to this
-//                              event, as a ```map[string]interface{}```. These attributes can be used in your triggers to control who should
-//                              receive the triggered email. You can set any number of data values.
+//                              event, as a ```map[string]interface{}```. 
+//                              These attributes can be used in your triggers to control who should
+//                              receive the triggered message. You can set any number of data values.
 
-track.TrackAnonymous("anonymous_id", "invite", map[string]interface{}{
+if err := track.TrackAnonymous("anonymous_id", "invite", map[string]interface{}{
     "first_name": "Alex",
     "source": "OldApp",
-})
+}); err != nil {
+  // handle error
+}
 ```
 
 ### Adding a device to a customer
@@ -176,47 +242,50 @@ In order to send push notifications, we need customer device information.
 // Arguments
 // customerID (required) - a unique identifier string for this customer
 // deviceID (required)   - a unique identifier string for this device
-// platform (required)   - the platform of the device, currently only accepts 'ios' and 'andriod'
-// data (optional)        - a ```map[string]interface{}``` of information about the device. You can pass any
-//                         key/value pairs that would be useful in your triggers. We
-//                         currently only save 'last_used'.
-//                         your interface{} should be parseable as Json by 'encoding/json'.Marshal
+// platform (required)   - the platform of the device, currently only accepts 'ios' and 'android'
+// data (optional)       - a ```map[string]interface{}``` of information about the device. 
+//                         You can pass any key/value pairs that would be useful in your triggers. 
+//                         We currently only save 'last_used'.
+//                         Your interface{} should be parseable as Json by 'encoding/json'.Marshal
 
-track.AddDevice("5", "messaging token", "android", map[string]interface{}{
+if err := track.AddDevice("5", "messaging token", "android", map[string]interface{}{
 "last_used": time.Now().Unix(),
-})
+}); err != nil {
+  // handle error
+}
 ```
 
 ### Deleting devices
 
-Deleting a device will remove it from the customers device list in Customer.io.
+Deleting a device will remove it from the customer's device list in Customer.io.
 
 ```go
 // Arguments
-// customerID (required) - the id of the customer the device you want to delete belongs to
-// deviceToken (required) - a unique identifier for the device.  This
-//                          should be the same id you'd pass into the
+// customerID (required)  - the id of the customer the device you want to delete belongs to
+// deviceToken (required) - a unique identifier for the device.
+//                          This should be the same id you'd pass into the
 //                          `addDevice` command above
 
-track.DeleteDevice("5", "messaging-token")
+if err := track.DeleteDevice("5", "messaging-token"); err != nil {
+  // handle error
+}
 ```
 
 ### Send Transactional Messages
 
-To use the Customer.io [Transactional API](https://customer.io/docs/transactional-api), create an instance of the API client using an [app key](https://customer.io/docs/managing-credentials#app-api-keys).
+To use the Customer.io [Transactional API](https://customer.io/docs/transactional-api), create an instance of the API client using an [App API key](https://customer.io/docs/managing-credentials#app-api-keys).
 
-Create a `SendEmailRequest` instance, and then use `SendEmail` to send your message. [Learn more about transactional messages and optional `SendEmailRequest` properties](https://customer.io/docs/transactional-api).
+Create a `customerio.SendEmailRequest` instance, and then use `(c *customerio.APIClient).SendEmail` to send your message. [Learn more about transactional messages and optional `SendEmailRequest` properties](https://customer.io/docs/transactional-api).
 
-You can also send attachments with your message. Use `Attach` to encode attachments.
+You can also send attachments with your message. Use `customerio.SendEmailRequest.Attach` to encode attachments.
 
 ```go
-import "github.com/customerio/go-customerio"
-
 client := customerio.NewAPIClient("<extapikey>", customerio.WithRegion(customerio.RegionUS));
 
 // TransactionalMessageId — the ID of the transactional message you want to send.
 // To                     — the email address of your recipients.
-// Identifiers            — contains the id of your recipient. If the id does not exist, Customer.io creates it.
+// Identifiers            — contains the id of your recipient. 
+//                          If the id does not exist, Customer.io creates it.
 // MessageData            — contains properties that you want reference in your message using liquid.
 // Attach                 — a helper that encodes attachments to your message.
 
@@ -239,13 +308,15 @@ request := customerio.SendEmailRequest{
 // (optional) attach a file to your message.
 f, err := os.Open("receipt.pdf")
 if err != nil {
-  fmt.Println(err)
+  // handle error
 }
+defer f.Close()
+
 request.Attach("receipt.pdf", f)
 
 body, err := client.SendEmail(context.Background(), &request)
 if err != nil {
-  fmt.Println(err)
+  // handle error
 }
 
 fmt.Println(body)
@@ -256,6 +327,6 @@ fmt.Println(body)
 1. Fork it
 2. Clone your fork (`git clone git@github.com:MY_USERNAME/go-customerio.git && cd go-customerio`)
 3. Create your feature branch (`git checkout -b my-new-feature`)
-4. Commit your changes (`git commit -am 'Added some feature'`)
+4. Commit your changes (`git commit -am 'feat: Added some feature'`)
 5. Push to the branch (`git push origin my-new-feature`)
 6. Create new Pull Request

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ![Latest release](https://img.shields.io/github/v/release/customerio/go-customerio)
 ![Software License](https://img.shields.io/github/license/customerio/go-customerio)
-[![Build status](https://github.com/customerio/go-customerio/actions/workflows/main.yml/badge.svg)](https://github.com/customerio/go-customerio/actions/workflows/main.yml)
+[![CI status](https://github.com/customerio/go-customerio/actions/workflows/main.yml/badge.svg)](https://github.com/customerio/go-customerio/actions/workflows/main.yml)
 ![Go version](https://img.shields.io/github/go-mod/go-version/customerio/go-customerio)
 [![Go Doc](https://img.shields.io/badge/Go_Doc-reference-blue.svg)](https://pkg.go.dev/github.com/customerio/go-customerio/v3)
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ![Latest release](https://img.shields.io/github/v/release/customerio/go-customerio)
 ![Software License](https://img.shields.io/github/license/customerio/go-customerio)
 [![CI status](https://github.com/customerio/go-customerio/actions/workflows/main.yml/badge.svg)](https://github.com/customerio/go-customerio/actions/workflows/main.yml)
+[![codecov](https://codecov.io/gh/customerio/go-customerio/branch/master/graph/badge.svg?token=D59CJnFVDV)](https://codecov.io/gh/customerio/go-customerio)
 ![Go version](https://img.shields.io/github/go-mod/go-version/customerio/go-customerio)
 [![Go Doc](https://img.shields.io/badge/Go_Doc-reference-blue.svg)](https://pkg.go.dev/github.com/customerio/go-customerio/v3)
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ And then execute:
 
 Or install it yourself:
 
-    $ go get github.com/customerio/go-customerio
+    $ go get github.com/customerio/go-customerio/v3
 
 ## Before we get started: API client vs. JavaScript snippet
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+# curl --data-binary @codecov.yml https://codecov.io/validate
+codecov:
+  require_ci_to_pass: yes
+  branch: main
+
+coverage:
+  precision: 2
+  round: down
+  range: "60...100"  # less than 60% having a red background
+
+comment:
+  layout: "reach,diff,flags"
+  behavior: default         #  update, if exists. Otherwise post new.
+  require_changes: true     # if true: only post the comment if coverage changes
+  require_base: no          # [yes :: must have a base report to post]
+  require_head: yes         # [yes :: must have a head report to post]

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/customerio/go-customerio/v3
 
-go 1.16
+go 1.17


### PR DESCRIPTION
This PR addresses some of the issues raised in #19. It adds Gitpod config to avoid running the default tasks Gitpod selects for Go projects. The README got an overhaul to correct a broken link and default links to HTTPS. Examples were cleaned up to include error basic error handling prompts to promote best practices.

I'm still working on this branch, I also want to look at the tests to see about testing on current stable - 2 (currently 1.17, 1.16, 1.15, and possibly tip as well. Would be good to bump the go.mod to stable (1.17).