### PR TITLE
feat: add support for invite-type anonymous event tracking

### DIFF
--- a/customerio.go
+++ b/customerio.go
@@ -113,13 +113,17 @@ func (c *CustomerIO) TrackAnonymousCtx(ctx context.Context, anonymousID, eventNa
 	if eventName == "" {
 		return ParamError{Param: "eventName"}
 	}
-	return c.request(ctx, "POST",
-		fmt.Sprintf("%s/api/v1/events", c.URL),
-		map[string]interface{}{
-			"name":         eventName,
-			"anonymous_id": anonymousID,
-			"data":         data,
-		})
+
+	payload := map[string]interface{}{
+		"name": eventName,
+		"data": data,
+	}
+
+	if anonymousID != "" {
+		payload["anonymous_id"] = anonymousID
+	}
+
+	return c.request(ctx, "POST", fmt.Sprintf("%s/api/v1/events", c.URL), payload)
 }
 
 // TrackAnonymous sends a single event to Customer.io for the anonymous user

--- a/customerio.go
+++ b/customerio.go
@@ -110,9 +110,6 @@ func (c *CustomerIO) Track(customerID string, eventName string, data map[string]
 
 // TrackAnonymousCtx sends a single event to Customer.io for the anonymous user
 func (c *CustomerIO) TrackAnonymousCtx(ctx context.Context, anonymousID, eventName string, data map[string]interface{}) error {
-	if anonymousID == "" {
-		return ParamError{Param: "anonymousID"}
-	}
 	if eventName == "" {
 		return ParamError{Param: "eventName"}
 	}


### PR DESCRIPTION
Re-introduces support for anonymous event tracking using activity items unassociated with profiles by passing in a blank value for `anonymous_id`

**Usage:**

```go
TrackAnonymousCtx(ctx, "", "my-event", map[string]interface{}{"foo": "bar"})
```