### PR TITLE
fix: Close encoder to flush any pending output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v3.4.0](https://github.com/customerio/go-customerio/compare/v3.4.0...v3.4.1) (2022-05-19)
+### Fixed
+- Resolved issue where some attachments were truncated due to not flushing all the data from the buffer.
+
+## [v3.4.0](https://github.com/customerio/go-customerio/compare/v3.3.0...v3.4.0) (2022-04-26)
+### Added
+- Added support for sending a blank value for anonymous activity, which will be treated as unassociated with a profile within Customer.io.
+
+## [v3.3.0](https://github.com/customerio/go-customerio/compare/v.3.2.0...v3.3.0) (2021-12-22)
+### Added
+- Added support for context to all API calls.
+
 ## [v3.2.0](https://github.com/customerio/go-customerio/compare/v3.1.0...v.3.2.0) (2021-10-04)
 ### Added
 - **client:** adds a default User-Agent header on requests and the option to set a custom User-Agent value. ([2123497](https://github.com/customerio/go-customerio/commit/212349768ba234d6c4ad3684aa6450f770f35cb8))

--- a/send_email.go
+++ b/send_email.go
@@ -47,8 +47,11 @@ func (e *SendEmailRequest) Attach(name string, value io.Reader) error {
 	if _, err := io.Copy(enc, value); err != nil {
 		return err
 	}
+	if err := enc.Close(); err != nil {
+		return err
+	}
 
-	e.Attachments[name] = string(buf.Bytes())
+	e.Attachments[name] = buf.String()
 	return nil
 }
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package customerio
 
-const Version = "3.3.0"
+const Version = "3.4.1"


### PR DESCRIPTION
Resolves issue where some attachments were truncated due to not flushing all the data from the buffer.