### PR TITLE
Transactional - amp_body prop to body_amp for consistency

### DIFF
--- a/send_email.go
+++ b/send_email.go
@@ -22,7 +22,7 @@ type SendEmailRequest struct {
 	Subject                 string                 `json:"subject,omitempty"`
 	Preheader               string                 `json:"preheader,omitempty"`
 	Body                    string                 `json:"body,omitempty"`
-	PlaintextBody           string                 `json:"body_plaintext,omitempty"`
+	PlaintextBody           string                 `json:"body_plain,omitempty"`
 	AMPBody                 string                 `json:"body_amp,omitempty"`
 	FakeBCC                 *bool                  `json:"fake_bcc,omitempty"`
 	Attachments             map[string]string      `json:"attachments,omitempty"`

--- a/send_email.go
+++ b/send_email.go
@@ -22,8 +22,8 @@ type SendEmailRequest struct {
 	Subject                 string                 `json:"subject,omitempty"`
 	Preheader               string                 `json:"preheader,omitempty"`
 	Body                    string                 `json:"body,omitempty"`
-	PlaintextBody           string                 `json:"plaintext_body,omitempty"`
-	AMPBody                 string                 `json:"amp_body,omitempty"`
+	PlaintextBody           string                 `json:"body_plaintext,omitempty"`
+	AMPBody                 string                 `json:"body_amp,omitempty"`
 	FakeBCC                 *bool                  `json:"fake_bcc,omitempty"`
 	Attachments             map[string]string      `json:"attachments,omitempty"`
 	DisableMessageRetention *bool                  `json:"disable_message_retention,omitempty"`


### PR DESCRIPTION
Updating Transactional API endpoint properties `amp_body` `amp_plaintext` to `body_amp` `body_plaintext` to maintain consistency across APIs.