### PR TITLE
HTTP client interface

### DIFF
--- a/api.go
+++ b/api.go
@@ -8,11 +8,15 @@ import (
 	"net/http"
 )
 
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 type APIClient struct {
 	Key       string
 	URL       string
 	UserAgent string
-	Client    *http.Client
+	Client    HTTPClient
 }
 
 // NewAPIClient prepares a client for use with the Customer.io API, see: https://customer.io/docs/api/#apicoreintroduction

--- a/customerio.go
+++ b/customerio.go
@@ -22,7 +22,7 @@ type CustomerIO struct {
 	apiKey    string
 	URL       string
 	UserAgent string
-	Client    *http.Client
+	Client    HTTPClient
 }
 
 // CustomerIOError is returned by any method that fails at the API level

--- a/options.go
+++ b/options.go
@@ -1,7 +1,5 @@
 package customerio
 
-import "net/http"
-
 type option struct {
 	api   func(*APIClient)
 	track func(*CustomerIO)
@@ -34,7 +32,7 @@ func WithRegion(r region) option {
 	}
 }
 
-func WithHTTPClient(client *http.Client) option {
+func WithHTTPClient(client HTTPClient) option {
 	return option{
 		api: func(a *APIClient) {
 			a.Client = client


### PR DESCRIPTION
Hi!

We've encountered an issue where our mocked HTTP client cannot be provided via options defined in the client library. Here is a PR with an example of how this could be resolved. I'd be glad to hear any thoughts or suggestions you may have.

Thank you!