### PR TITLE
Support for inbox message transactional API

### DIFF
--- a/send_inbox_message.go
+++ b/send_inbox_message.go
@@ -4,32 +4,28 @@ import (
 	"context"
 )
 
-type SendSMSRequest struct {
+type SendInboxMessageRequest struct {
 	MessageData             map[string]interface{} `json:"message_data,omitempty"`
 	TransactionalMessageID  string                 `json:"transactional_message_id,omitempty"`
 	Identifiers             map[string]string      `json:"identifiers"`
 	DisableMessageRetention *bool                  `json:"disable_message_retention,omitempty"`
-	SendToUnsubscribed      *bool                  `json:"send_to_unsubscribed,omitempty"`
 	QueueDraft              *bool                  `json:"queue_draft,omitempty"`
 	SendAt                  *int64                 `json:"send_at,omitempty"`
 	Language                *string                `json:"language,omitempty"`
-
-	From string `json:"from,omitempty"`
-	To   string `json:"to,omitempty"`
 }
 
-type SendSMSResponse struct {
+type SendInboxMessageResponse struct {
 	TransactionalResponse
 }
 
-// SendSMS sends a single transactional SMS using the Customer.io transactional API
-func (c *APIClient) SendSMS(ctx context.Context, req *SendSMSRequest) (*SendSMSResponse, error) {
-	resp, err := c.sendTransactional(ctx, TransactionalTypeSMS, req)
+// SendInboxMessage sends a single transactional inbox message using the Customer.io transactional API
+func (c *APIClient) SendInboxMessage(ctx context.Context, req *SendInboxMessageRequest) (*SendInboxMessageResponse, error) {
+	resp, err := c.sendTransactional(ctx, TransactionalTypeInboxMessage, req)
 	if err != nil {
 		return nil, err
 	}
 
-	return &SendSMSResponse{
+	return &SendInboxMessageResponse{
 		*resp,
 	}, nil
 }

--- a/send_inbox_message_test.go
+++ b/send_inbox_message_test.go
@@ -1,0 +1,53 @@
+package customerio_test
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/customerio/go-customerio/v3"
+)
+
+func TestSendInboxMessage(t *testing.T) {
+	req := &customerio.SendInboxMessageRequest{
+		TransactionalMessageID: "123456",
+		Identifiers: map[string]string{
+			"id": "customer_1",
+		},
+		MessageData: map[string]interface{}{
+			"token": "123456",
+		},
+	}
+
+	var verify = func(request []byte) {
+		var body customerio.SendInboxMessageRequest
+		if err := json.Unmarshal(request, &body); err != nil {
+			t.Error(err)
+		}
+
+		if !reflect.DeepEqual(&body, req) {
+			t.Errorf("Request differed, want: %#v, got: %#v", request, body)
+		}
+	}
+
+	api, srv := transactionalServer(t, verify)
+	defer srv.Close()
+
+	resp, err := api.SendInboxMessage(context.Background(), req)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expect := &customerio.SendInboxMessageResponse{
+		TransactionalResponse: customerio.TransactionalResponse{
+			DeliveryID: testDeliveryID,
+			QueuedAt:   time.Unix(int64(testQueuedAt), 0),
+		},
+	}
+
+	if !reflect.DeepEqual(resp, expect) {
+		t.Errorf("Expect: %#v, Got: %#v", expect, resp)
+	}
+}

--- a/transactional.go
+++ b/transactional.go
@@ -12,15 +12,17 @@ import (
 type TransactionalType int
 
 const (
-	TransactionalTypeEmail = 0
-	TransactionalTypePush  = 1
-	TransactionalTypeSMS   = 2
+	TransactionalTypeEmail        = 0
+	TransactionalTypePush         = 1
+	TransactionalTypeSMS          = 2
+	TransactionalTypeInboxMessage = 3
 )
 
 var typeToApi = map[TransactionalType]string{
-	TransactionalTypeEmail: "email",
-	TransactionalTypePush:  "push",
-	TransactionalTypeSMS:   "sms",
+	TransactionalTypeEmail:        "email",
+	TransactionalTypePush:         "push",
+	TransactionalTypeSMS:          "sms",
+	TransactionalTypeInboxMessage: "inbox_message",
 }
 
 var ErrInvalidTransactionalMessageType = errors.New("unknown transactional message type")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, additive change that reuses existing transactional sending logic; primary risk is incorrect endpoint/type mapping for the new inbox message mode.
> 
> **Overview**
> Adds a new `SendInboxMessage` transactional send API, including request/response types, wired through the shared `sendTransactional` helper.
> 
> Extends `TransactionalType`/`typeToApi` mapping with a new `inbox_message` endpoint and fixes a misleading comment on `SendSMS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6027ab5d6a5cd091b6d1cd497a6b2a784dc81037. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->