### PR TITLE
add support for sending transactional in-app messages

### DIFF
--- a/send_in_app.go
+++ b/send_in_app.go
@@ -1,0 +1,31 @@
+package customerio
+
+import (
+	"context"
+)
+
+type SendInAppRequest struct {
+	MessageData             map[string]interface{} `json:"message_data,omitempty"`
+	TransactionalMessageID  string                 `json:"transactional_message_id,omitempty"`
+	Identifiers             map[string]string      `json:"identifiers"`
+	DisableMessageRetention *bool                  `json:"disable_message_retention,omitempty"`
+	QueueDraft              *bool                  `json:"queue_draft,omitempty"`
+	SendAt                  *int64                 `json:"send_at,omitempty"`
+	Language                *string                `json:"language,omitempty"`
+}
+
+type SendInAppResponse struct {
+	TransactionalResponse
+}
+
+// SendInApp sends a single transactional in-app message using the Customer.io transactional API
+func (c *APIClient) SendInApp(ctx context.Context, req *SendInAppRequest) (*SendInAppResponse, error) {
+	resp, err := c.sendTransactional(ctx, TransactionalTypeInApp, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SendInAppResponse{
+		*resp,
+	}, nil
+}

--- a/send_in_app.go
+++ b/send_in_app.go
@@ -5,7 +5,7 @@ import (
 )
 
 type SendInAppRequest struct {
-	MessageData             map[string]interface{} `json:"message_data,omitempty"`
+	MessageData             map[string]any `json:"message_data,omitempty"`
 	TransactionalMessageID  string                 `json:"transactional_message_id,omitempty"`
 	Identifiers             map[string]string      `json:"identifiers"`
 	DisableMessageRetention *bool                  `json:"disable_message_retention,omitempty"`

--- a/send_in_app.go
+++ b/send_in_app.go
@@ -5,7 +5,7 @@ import (
 )
 
 type SendInAppRequest struct {
-	MessageData             map[string]any `json:"message_data,omitempty"`
+	MessageData             map[string]interface{} `json:"message_data,omitempty"`
 	TransactionalMessageID  string                 `json:"transactional_message_id,omitempty"`
 	Identifiers             map[string]string      `json:"identifiers"`
 	DisableMessageRetention *bool                  `json:"disable_message_retention,omitempty"`

--- a/send_in_app_test.go
+++ b/send_in_app_test.go
@@ -1,0 +1,53 @@
+package customerio_test
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/customerio/go-customerio/v3"
+)
+
+func TestSendInApp(t *testing.T) {
+	req := &customerio.SendInAppRequest{
+		TransactionalMessageID: "123456",
+		Identifiers: map[string]string{
+			"id": "customer_1",
+		},
+		MessageData: map[string]interface{}{
+			"token": "123456",
+		},
+	}
+
+	var verify = func(request []byte) {
+		var body customerio.SendInAppRequest
+		if err := json.Unmarshal(request, &body); err != nil {
+			t.Error(err)
+		}
+
+		if !reflect.DeepEqual(&body, req) {
+			t.Errorf("Request differed, want: %#v, got: %#v", request, body)
+		}
+	}
+
+	api, srv := transactionalServer(t, verify)
+	defer srv.Close()
+
+	resp, err := api.SendInApp(context.Background(), req)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expect := &customerio.SendInAppResponse{
+		TransactionalResponse: customerio.TransactionalResponse{
+			DeliveryID: testDeliveryID,
+			QueuedAt:   time.Unix(int64(testQueuedAt), 0),
+		},
+	}
+
+	if !reflect.DeepEqual(resp, expect) {
+		t.Errorf("Expect: %#v, Got: %#v", expect, resp)
+	}
+}

--- a/transactional.go
+++ b/transactional.go
@@ -16,6 +16,7 @@ const (
 	TransactionalTypePush         = 1
 	TransactionalTypeSMS          = 2
 	TransactionalTypeInboxMessage = 3
+	TransactionalTypeInApp        = 4
 )
 
 var typeToApi = map[TransactionalType]string{
@@ -23,6 +24,7 @@ var typeToApi = map[TransactionalType]string{
 	TransactionalTypePush:         "push",
 	TransactionalTypeSMS:          "sms",
 	TransactionalTypeInboxMessage: "inbox_message",
+	TransactionalTypeInApp:        "in_app",
 }
 
 var ErrInvalidTransactionalMessageType = errors.New("unknown transactional message type")


### PR DESCRIPTION
Adds `SendInApp` method and `SendInAppRequest`/`SendInAppResponse` types for the `POST /v1/send/in_app` transactional API endpoint. Follows the same pattern as the existing inbox message support.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive and reuse existing `sendTransactional` flow, with only a small extension to the transactional type-to-API mapping.
> 
> **Overview**
> Adds support for sending transactional *in-app* messages by introducing `SendInAppRequest`/`SendInAppResponse` and a new `APIClient.SendInApp` method that routes through the existing transactional send helper.
> 
> Extends `TransactionalType` and its `typeToApi` mapping with `in_app`, and adds a unit test to verify request serialization and response parsing for the new API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c852c6d40b5d39acbf724b29f0635b360ee1d5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->