### PR TITLE
Release v3.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v3.8.0]
+### Added
+- Add support for sending transactional in-app messages ([#55](https://github.com/customerio/go-customerio/pull/55))
+
 ## [v3.4.1](https://github.com/customerio/go-customerio/compare/v3.4.0...v3.4.1) (2022-05-19)
 ### Fixed
 - Resolved issue where some attachments were truncated due to not flushing all the data from the buffer.

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package customerio
 
-const Version = "3.5.0"
+const Version = "3.8.0"


### PR DESCRIPTION
Updates the changelog for v3.8.0.

#### Added
- Add support for sending transactional in-app messages ([#55](https://github.com/customerio/go-customerio/pull/55))

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only (version constant and changelog update) with no runtime behavior changes in this PR.
> 
> **Overview**
> Prepares the `v3.8.0` release by updating `Version` to `3.8.0` and adding a `v3.8.0` changelog entry noting support for sending transactional in-app messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74faff86bac2fe3ea0822138d69eeba6f06b0248. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->