### PR TITLE
add funcopts for setting fields in Track calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,17 @@ if err := track.Track("5", "purchase", map[string]interface{}{
 }
 ```
 
+Use event options when you need to set top-level event fields like `id`, `timestamp`, or `type`.
+
+```go
+if err := track.Track("5", "purchase", map[string]interface{}{
+    "type": "socks",
+    "price": "13.99",
+}, customerio.WithEventTimestamp(time.Now()), customerio.WithEventID("evt_123")); err != nil {
+  // handle error
+}
+```
+
 ### Tracking an anonymous event
 
 You can also send anonymous events representing people you haven't identified. An anonymous event requires an `anonymous_id` representing the unknown person and an event `name`. When you identify a person, you can set their `anonymous_id` attribute. If [event merging](https://customer.io/docs/anonymous-events/#turn-on-merging) is turned on in your workspace, and the attribute matches the `anonymous_id` in one or more events that were logged within the last 30 days, we associate those events with the person.

--- a/customerio.go
+++ b/customerio.go
@@ -88,7 +88,7 @@ func (c *CustomerIO) Identify(customerID string, attributes map[string]interface
 }
 
 // TrackCtx sends a single event to Customer.io for the supplied user
-func (c *CustomerIO) TrackCtx(ctx context.Context, customerID string, eventName string, data map[string]interface{}) error {
+func (c *CustomerIO) TrackCtx(ctx context.Context, customerID string, eventName string, data map[string]interface{}, opts ...TrackOption) error {
 	if customerID == "" {
 		return ParamError{Param: "customerID"}
 	}
@@ -97,27 +97,21 @@ func (c *CustomerIO) TrackCtx(ctx context.Context, customerID string, eventName 
 	}
 	return c.request(ctx, "POST",
 		fmt.Sprintf("%s/api/v1/customers/%s/events", c.URL, url.PathEscape(customerID)),
-		map[string]interface{}{
-			"name": eventName,
-			"data": data,
-		})
+		trackPayload(eventName, data, opts...))
 }
 
 // Track sends a single event to Customer.io for the supplied user
-func (c *CustomerIO) Track(customerID string, eventName string, data map[string]interface{}) error {
-	return c.TrackCtx(context.Background(), customerID, eventName, data)
+func (c *CustomerIO) Track(customerID string, eventName string, data map[string]interface{}, opts ...TrackOption) error {
+	return c.TrackCtx(context.Background(), customerID, eventName, data, opts...)
 }
 
 // TrackAnonymousCtx sends a single event to Customer.io for the anonymous user
-func (c *CustomerIO) TrackAnonymousCtx(ctx context.Context, anonymousID, eventName string, data map[string]interface{}) error {
+func (c *CustomerIO) TrackAnonymousCtx(ctx context.Context, anonymousID, eventName string, data map[string]interface{}, opts ...TrackOption) error {
 	if eventName == "" {
 		return ParamError{Param: "eventName"}
 	}
 
-	payload := map[string]interface{}{
-		"name": eventName,
-		"data": data,
-	}
+	payload := trackPayload(eventName, data, opts...)
 
 	if anonymousID != "" {
 		payload["anonymous_id"] = anonymousID
@@ -127,8 +121,8 @@ func (c *CustomerIO) TrackAnonymousCtx(ctx context.Context, anonymousID, eventNa
 }
 
 // TrackAnonymous sends a single event to Customer.io for the anonymous user
-func (c *CustomerIO) TrackAnonymous(anonymousID, eventName string, data map[string]interface{}) error {
-	return c.TrackAnonymousCtx(context.Background(), anonymousID, eventName, data)
+func (c *CustomerIO) TrackAnonymous(anonymousID, eventName string, data map[string]interface{}, opts ...TrackOption) error {
+	return c.TrackAnonymousCtx(context.Background(), anonymousID, eventName, data, opts...)
 }
 
 // DeleteCtx deletes a customer

--- a/customerio_test.go
+++ b/customerio_test.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/customerio/go-customerio/v3"
 )
@@ -104,6 +105,35 @@ func TestTrack(t *testing.T) {
 		})
 }
 
+func TestTrackWithOptions(t *testing.T) {
+	data := map[string]interface{}{
+		"a": "1",
+	}
+	timestamp := time.Unix(1640995200, 0)
+
+	body := map[string]interface{}{
+		"name":      "test",
+		"id":        "evt_123",
+		"timestamp": timestamp.Unix(),
+		"type":      customerio.TrackTypePage,
+		"data": map[string]interface{}{
+			"a": "1",
+		},
+	}
+
+	expect("POST", "/api/v1/customers/1/events", body)
+	if err := cio.Track(
+		"1",
+		"test",
+		data,
+		customerio.WithEventID("evt_123"),
+		customerio.WithEventTimestamp(timestamp),
+		customerio.WithEventType(customerio.TrackTypePage),
+	); err != nil {
+		t.Error(err.Error())
+	}
+}
+
 func TestTrackAnonymous(t *testing.T) {
 	data := map[string]interface{}{
 		"a": "1",
@@ -119,6 +149,36 @@ func TestTrackAnonymous(t *testing.T) {
 
 	expect("POST", "/api/v1/events", body)
 	if err := cio.TrackAnonymous("anon123", "test", data); err != nil {
+		t.Error(err.Error())
+	}
+}
+
+func TestTrackAnonymousWithOptions(t *testing.T) {
+	data := map[string]interface{}{
+		"a": "1",
+	}
+	timestamp := time.Unix(1640995200, 0)
+
+	body := map[string]interface{}{
+		"name":         "test",
+		"anonymous_id": "anon123",
+		"id":           "evt_123",
+		"timestamp":    timestamp.Unix(),
+		"type":         customerio.TrackTypeScreen,
+		"data": map[string]interface{}{
+			"a": "1",
+		},
+	}
+
+	expect("POST", "/api/v1/events", body)
+	if err := cio.TrackAnonymous(
+		"anon123",
+		"test",
+		data,
+		customerio.WithEventID("evt_123"),
+		customerio.WithEventTimestamp(timestamp),
+		customerio.WithEventType(customerio.TrackTypeScreen),
+	); err != nil {
 		t.Error(err.Error())
 	}
 }

--- a/options.go
+++ b/options.go
@@ -1,5 +1,7 @@
 package customerio
 
+import "time"
+
 type option struct {
 	api   func(*APIClient)
 	track func(*CustomerIO)
@@ -52,4 +54,50 @@ func WithUserAgent(ua string) option {
 			c.UserAgent = ua
 		},
 	}
+}
+
+// TrackOption sets optional top-level fields on tracked events.
+type TrackOption func(map[string]interface{})
+
+// TrackType is the type of event being tracked.
+type TrackType string
+
+const (
+	TrackTypeEvent  TrackType = "event"
+	TrackTypePage   TrackType = "page"
+	TrackTypeScreen TrackType = "screen"
+)
+
+// WithEventID sets the id field on tracked events.
+func WithEventID(id string) TrackOption {
+	return func(payload map[string]interface{}) {
+		payload["id"] = id
+	}
+}
+
+// WithEventTimestamp sets the timestamp field on tracked events.
+func WithEventTimestamp(timestamp time.Time) TrackOption {
+	return func(payload map[string]interface{}) {
+		payload["timestamp"] = timestamp.Unix()
+	}
+}
+
+// WithEventType sets the type field on tracked events.
+func WithEventType(typ TrackType) TrackOption {
+	return func(payload map[string]interface{}) {
+		payload["type"] = typ
+	}
+}
+
+func trackPayload(eventName string, data map[string]interface{}, opts ...TrackOption) map[string]interface{} {
+	payload := map[string]interface{}{
+		"name": eventName,
+		"data": data,
+	}
+
+	for _, opt := range opts {
+		opt(payload)
+	}
+
+	return payload
 }


### PR DESCRIPTION
Adds support for setting some previously inaccessible fields when doing a `track` call

resolves https://github.com/customerio/go-customerio/issues/57 and adds the same featureset as https://github.com/customerio/go-customerio/pull/35

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public `Track*` method signatures change to accept variadic `TrackOption`s, which is source-breaking for downstream callers. Runtime risk is low but incorrect option usage could alter event payloads sent to the Track API.
> 
> **Overview**
> Adds variadic `TrackOption`s to `Track`, `TrackCtx`, `TrackAnonymous`, and `TrackAnonymousCtx`, allowing callers to set top-level event fields (`id`, `timestamp`, `type`) on Track API payloads via new helpers like `WithEventID`, `WithEventTimestamp`, and `WithEventType`.
> 
> Updates tests to validate the new payload shape when options are provided, and extends the README with an example of using event options during `Track` calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cdceb8348ee6e7c123d5f9978cc9cdad5e0a743. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->