### PR TITLE
Modernize

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,8 @@ name: ci
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.21.x", "1.22.x", "1.23.x", "1.24.x", "stable"]
+        go: ["1.21.x", "1.22.x", "1.23.x", "1.24.x", "1.25.x", "1.26.x", "stable"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5.5.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,22 +1,39 @@
 name: ci
 
-on: [ push ]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   test:
+    name: Go ${{ matrix.go }} test
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        go: [ '1.21.x', '1.22.x', '1.23.x', '1.24.x', 'stable' ]
-    name: Go ${{ matrix.go }} test
+        go: ["1.21.x", "1.22.x", "1.23.x", "1.24.x", "stable"]
     steps:
       - uses: actions/checkout@v4
-      - name: Install stable Go
-        uses: actions/setup-go@v5.5.0
+      - uses: actions/setup-go@v5.5.0
         with:
           go-version: ${{ matrix.go }}
+          cache: true
       - run: go version
-      - name: Setup gotestsum
-        run: |
-          curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v1.12.2/gotestsum_1.12.2_linux_amd64.tar.gz" | sudo tar -xz -C /usr/local/bin gotestsum
-      - run: go test -race
+      - run: go test -race ./...
+      - run: go test -coverprofile=coverage.out ./...
+
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5.5.0
+        with:
+          go-version: stable
+          cache: true
+      - run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - run: govulncheck ./...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,6 @@ jobs:
         with:
           go-version: stable
           cache: true
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v7
         with:
           version: v2.11.3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,3 +37,16 @@ jobs:
           cache: true
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - run: govulncheck ./...
+
+  lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5.5.0
+        with:
+          go-version: stable
+          cache: true
+      - uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.11.3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,8 @@ jobs:
       matrix:
         go: ["1.21.x", "1.22.x", "1.23.x", "1.24.x", "1.25.x", "stable"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5.5.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ matrix.go }}
           cache: true
@@ -31,8 +31,8 @@ jobs:
     name: govulncheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5.5.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: stable
           cache: true
@@ -43,11 +43,11 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5.5.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: stable
           cache: true
-      - uses: golangci/golangci-lint-action@v7
+      - uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
         with:
           version: v2.11.3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.21.x", "1.22.x", "1.23.x", "1.24.x", "1.25.x", "1.26.x", "stable"]
+        go: ["1.21.x", "1.22.x", "1.23.x", "1.24.x", "1.25.x", "stable"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5.5.0
@@ -24,7 +24,6 @@ jobs:
           cache: true
       - run: go version
       - run: go test -race ./...
-      - run: go test -coverprofile=coverage.out ./...
 
   govulncheck:
     name: govulncheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,11 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: standard
+
+formatters:
+  enable:
+    - gofmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+### Changed
+- `Device` now exposes a `Token` field for transactional push custom-device payloads to match the `token` JSON field.
+
+### Fixed
+- Preserved existing default HTTP behavior: API clients use `http.DefaultClient`, track clients do not set a default timeout, and Basic auth continues to use the previous URL-safe base64 encoding.
+- Made the default track transport safe when `http.DefaultTransport` is replaced by instrumentation.
+- Hardened client options and region selection against nil options and mutable package-level region values.
+
 ## [v3.8.0]
 ### Added
 - Add support for sending transactional in-app messages ([#55](https://github.com/customerio/go-customerio/pull/55))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 - `Device` now exposes a `Token` field for transactional push custom-device payloads to match the `token` JSON field.
 
 ### Fixed
-- Preserved existing default HTTP behavior: API clients use `http.DefaultClient`, track clients do not set a default timeout, and Basic auth continues to use the previous URL-safe base64 encoding.
-- Made the default track transport safe when `http.DefaultTransport` is replaced by instrumentation.
+- Default clients now use a 30 second HTTP timeout, and Basic auth continues to use the previous URL-safe base64 encoding.
+- Made the default transport safe when `http.DefaultTransport` is replaced by instrumentation.
 - Hardened client options and region selection against nil options and mutable package-level region values.
 
 ## [v3.8.0]

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Your account region (`customerio.RegionUS` or `customerio.RegionEU`) is optional
 
 If your account is based in the EU and you do not provide the correct region, we'll route requests from the US to `customerio.RegionEU` accordingly, however this may cause data to be logged in the US.
 
-By default, clients use a 30 second HTTP timeout. To use a different timeout, transport, or proxy policy, pass your own `*http.Client` with `customerio.WithHTTPClient`.
+To use a custom timeout, transport, or proxy policy, pass your own `*http.Client` with `customerio.WithHTTPClient`.
 
 ### Identify logged in customers
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Your account region (`customerio.RegionUS` or `customerio.RegionEU`) is optional
 
 If your account is based in the EU and you do not provide the correct region, we'll route requests from the US to `customerio.RegionEU` accordingly, however this may cause data to be logged in the US.
 
-To use a custom timeout, transport, or proxy policy, pass your own `*http.Client` with `customerio.WithHTTPClient`.
+By default, clients use a 30 second HTTP timeout. To use a custom timeout, transport, or proxy policy, pass your own `*http.Client` with `customerio.WithHTTPClient`.
 
 ### Identify logged in customers
 

--- a/README.md
+++ b/README.md
@@ -183,11 +183,14 @@ if err := track.Delete("5"); err != nil {
 
 When you merge two people, you pick a primary person and merge a secondary, duplicate person into the primary person. The primary person remains after the merge and the secondary person is deleted. This process is permanent: you cannot recover the secondary person.
 
-The first and third parameters represent the identifier for the primary and secondary people respectively, one of `id`, `email`, or `cio_id`. The second and fourth parameters are the identifier values for the primary and secondary people, respectively.
+Use `Identifier` structs to specify the primary and secondary people to merge. Each identifier specifies a type (`id`, `email`, or `cio_id`) and a value.
 
 ```go
-if err := track.MergeCustomers(customerio.IdentifierTypeEmail, "cool.person@company.com", customerio.IdentifierTypeCioID, "C123"); err != nil {
-  // handle error
+if err := track.MergeCustomers(
+    customerio.Identifier{Type: customerio.IdentifierTypeEmail, Value: "cool.person@company.com"},
+    customerio.Identifier{Type: customerio.IdentifierTypeCioID, Value: "C123"},
+); err != nil {
+    // handle error
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Your account region (`customerio.RegionUS` or `customerio.RegionEU`) is optional
 
 If your account is based in the EU and you do not provide the correct region, we'll route requests from the US to `customerio.RegionEU` accordingly, however this may cause data to be logged in the US. 
 
+By default, clients use a 30 second HTTP timeout. To use a different timeout, transport, or proxy policy, pass your own `*http.Client` with `customerio.WithHTTPClient`.
+
 ### Identify logged in customers
 
 Tracking data of logged in customers is a key part of [Customer.io](https://customer.io). In order to send triggered messages, we must know the email address of the customer to send email or the phone number for SMS.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ![Go version](https://img.shields.io/github/go-mod/go-version/customerio/go-customerio)
 [![Go Doc](https://img.shields.io/badge/Go_Doc-reference-blue.svg)](https://pkg.go.dev/github.com/customerio/go-customerio/v3)
 
-# Customer.io Journeys Go Client 
+# Customer.io Journeys Go Client
 
 A Go client library for the [Customer.io Journeys Track API](https://customer.io/docs/api/track). If you're new to Customer.io, we recommend that you integrate with our [Data Pipelines Go client](https://github.com/customerio/cdp-analytics-go) instead.
 
@@ -82,7 +82,7 @@ func main() {
 	track := customerio.NewTrackClient(siteID, trackAPIKey, customerio.WithRegion(customerio.RegionUS))
 
 	// Send an Identify TrackAPI call
-	if err := track.Identify("5", map[string]interface{}{
+	if err := track.Identify("5", map[string]any{
 		"email":      "lucy@example.com",
 		"created_at": time.Now().Unix(),
 		"first_name": "Lucy",
@@ -106,7 +106,7 @@ func main() {
 		From:    "business@example.com",
 		Subject: "hello, {{ trigger.name }}",
 		Body:    "hello from the Customer.io {{ trigger.client }} client",
-		MessageData: map[string]interface{}{
+		MessageData: map[string]any{
 			"client": "Go",
 			"name":   "gopher",
 		},
@@ -123,9 +123,9 @@ func main() {
 
 ```
 
-Your account region (`customerio.RegionUS` or `customerio.RegionEU`) is optional. If you do not specify your region, we assume that your account is based in the US (`customerio.RegionUS`). 
+Your account region (`customerio.RegionUS` or `customerio.RegionEU`) is optional. If you do not specify your region, we assume that your account is based in the US (`customerio.RegionUS`).
 
-If your account is based in the EU and you do not provide the correct region, we'll route requests from the US to `customerio.RegionEU` accordingly, however this may cause data to be logged in the US. 
+If your account is based in the EU and you do not provide the correct region, we'll route requests from the US to `customerio.RegionEU` accordingly, however this may cause data to be logged in the US.
 
 By default, clients use a 30 second HTTP timeout. To use a different timeout, transport, or proxy policy, pass your own `*http.Client` with `customerio.WithHTTPClient`.
 
@@ -146,12 +146,12 @@ You'll want to identify your customers when they sign up for your product and an
 ```go
 // Arguments
 // customerID (required) - a unique identifier string for this customers
-// attributes (required) - a ```map[string]interface{}``` of information about the customer. You can pass any
+// attributes (required) - a ```map[string]any``` of information about the customer. You can pass any
 //                         information that would be useful in your triggers. You
 //                         should at least pass in an email, and created_at timestamp.
-//                         your interface{} should be parseable as JSON by 'encoding/json'.Marshal
+//                         your values should be parseable as JSON by 'encoding/json'.Marshal
 
-if err := track.Identify("5", map[string]interface{}{
+if err := track.Identify("5", map[string]any{
   "email": "bob@example.com",
   "created_at": time.Now().Unix(),
   "first_name": "Bob",
@@ -193,7 +193,7 @@ if err := track.MergeCustomers(customerio.IdentifierTypeEmail, "cool.person@comp
 
 ### Tracking a custom event
 
-Now that you're identifying your customers with [Customer.io](https://customer.io), you can now send events like "purchased" or "watchedIntroVideo". 
+Now that you're identifying your customers with [Customer.io](https://customer.io), you can now send events like "purchased" or "watchedIntroVideo".
 
 These allow you to more specifically target your users with automated messages, and track conversions when you're sending automated messages to encourage your customers to perform an action.
 
@@ -202,11 +202,11 @@ These allow you to more specifically target your users with automated messages, 
 // customerID (required)  - the id of the customer who you want to associate with the event.
 // name (required)        - the name of the event you want to track.
 // attributes (optional)  - any related information you'd like to attach to this
-//                          event, as a ```map[string]interface{}```. 
+//                          event, as a ```map[string]any```.
 //                          These attributes can be used in your triggers to control who should
 //                          receive the triggered message. You can set any number of data values.
 
-if err := track.Track("5", "purchase", map[string]interface{}{
+if err := track.Track("5", "purchase", map[string]any{
     "type": "socks",
     "price": "13.99",
 }); err != nil {
@@ -223,11 +223,11 @@ You can also send anonymous events representing people you haven't identified. A
 // anonymous_id (required)    - nullable, an identifier representing an unknown person.
 // name (required)            - the name of the event you want to track.
 // attributes (optional)      - any related information you'd like to attach to this
-//                              event, as a ```map[string]interface{}```. 
+//                              event, as a ```map[string]any```.
 //                              These attributes can be used in your triggers to control who should
 //                              receive the triggered message. You can set any number of data values.
 
-if err := track.TrackAnonymous("anonymous_id", "invite", map[string]interface{}{
+if err := track.TrackAnonymous("anonymous_id", "invite", map[string]any{
     "first_name": "Alex",
     "source": "OldApp",
 }); err != nil {
@@ -236,10 +236,10 @@ if err := track.TrackAnonymous("anonymous_id", "invite", map[string]interface{}{
 ```
 #### Anonymous invite events
 
-If you previously sent [invite events](https://customer.io/docs/anonymous-invite-emails/), you can achieve the same functionality by sending an anonymous event an empty string for the anonymous identifier. To send anonymous invites, your event *must* include a `recipient` attribute. 
+If you previously sent [invite events](https://customer.io/docs/anonymous-invite-emails/), you can achieve the same functionality by sending an anonymous event an empty string for the anonymous identifier. To send anonymous invites, your event *must* include a `recipient` attribute.
 
 ```go
-if err := track.TrackAnonymous("", "invite", map[string]interface{}{
+if err := track.TrackAnonymous("", "invite", map[string]any{
     "first_name": "Alex",
     "recipient": "alex.person@example.com",
 }); err != nil {
@@ -256,11 +256,11 @@ In order to send push notifications, we need customer device information.
 // customerID (required) - a unique identifier string for this customer
 // deviceID (required)   - a unique identifier string for this device
 // platform (required)   - the platform of the device, currently only accepts 'ios' and 'android'
-// data (optional)       - a ```map[string]interface{}``` of information about the device. 
-//                         You can pass any key/value pairs that would be useful in your triggers. 
-//                         Your interface{} should be parseable as Json by 'encoding/json'.Marshal
+// data (optional)       - a ```map[string]any``` of information about the device.
+//                         You can pass any key/value pairs that would be useful in your triggers.
+//                         Your values should be parseable as Json by 'encoding/json'.Marshal
 
-if err := track.AddDevice("5", "messaging token", "android", map[string]interface{}{
+if err := track.AddDevice("5", "messaging token", "android", map[string]any{
 "last_used": time.Now().Unix(),
 "attribute_name": "attribute_value",
 }); err != nil {
@@ -298,7 +298,7 @@ client := customerio.NewAPIClient("<extapikey>", customerio.WithRegion(customeri
 
 // TransactionalMessageId — the ID of the transactional message you want to send.
 // To                     — the email address of your recipients.
-// Identifiers            — contains the email and/or id of your recipient. 
+// Identifiers            — contains the email and/or id of your recipient.
 //                          If the person does not exist, Customer.io creates them.
 // MessageData            — contains properties that you want reference in your message using liquid.
 // Attach                 — a helper that encodes attachments to your message.
@@ -306,13 +306,13 @@ client := customerio.NewAPIClient("<extapikey>", customerio.WithRegion(customeri
 request := customerio.SendEmailRequest{
   To: "person@example.com",
   TransactionalMessageID: "3",
-  MessageData: map[string]interface{}{
+  MessageData: map[string]any{
     "name": "Person",
-    "items": map[string]interface{}{
+    "items": map[string]any{
       "name": "shoes",
       "price": "59.99",
     },
-    "products": []interface{}{},
+    "products": []any{},
   },
   Identifiers: map[string]string{
     "email": "person@example.com",
@@ -344,13 +344,13 @@ client := customerio.NewAPIClient("<extapikey>", customerio.WithRegion(customeri
 
 request := customerio.SendPushRequest{
   TransactionalMessageID: "3",
-  MessageData: map[string]interface{}{
+  MessageData: map[string]any{
     "name": "Person",
-    "items": map[string]interface{}{
+    "items": map[string]any{
       "name": "shoes",
       "price": "59.99",
     },
-    "products": []interface{}{},
+    "products": []any{},
   },
   Identifiers: map[string]string{
     "id": "example1",
@@ -358,7 +358,7 @@ request := customerio.SendPushRequest{
 }
 
 // (optional) upsert a particular device for the profile the push is being sent to.
-device, err := customerio.NewDevice("device-id", "android", map[string]interface{}{"optional_attr": "value"})
+device, err := customerio.NewDevice("device-id", "android", map[string]any{"optional_attr": "value"})
 if err != nil {
   // handle error, invalid device params.
 }
@@ -382,7 +382,7 @@ track := customerio.NewTrackClient(siteID, trackAPIKey, customerio.WithRegion(cu
 ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(5*time.Second))
 defer cancel()
 
-if err := track.TrackCtx(ctx, "5", "purchase", map[string]interface{}{
+if err := track.TrackCtx(ctx, "5", "purchase", map[string]any{
     "type": "socks",
     "price": "13.99",
 }); err != nil {

--- a/api.go
+++ b/api.go
@@ -21,7 +21,7 @@ type APIClient struct {
 
 // NewAPIClient prepares a client for use with the Customer.io API, see: https://customer.io/docs/api/#apicoreintroduction
 // using an App API Key from https://fly.customer.io/settings/api_credentials?keyType=app
-func NewAPIClient(key string, opts ...option) *APIClient {
+func NewAPIClient(key string, opts ...Option) *APIClient {
 	client := &APIClient{
 		Key:       key,
 		Client:    newDefaultHTTPClient(),

--- a/api.go
+++ b/api.go
@@ -24,13 +24,15 @@ type APIClient struct {
 func NewAPIClient(key string, opts ...Option) *APIClient {
 	client := &APIClient{
 		Key:       key,
-		Client:    newDefaultHTTPClient(),
+		Client:    http.DefaultClient,
 		URL:       "https://api.customer.io",
 		UserAgent: DefaultUserAgent,
 	}
 
 	for _, opt := range opts {
-		opt.api(client)
+		if opt != nil {
+			opt.applyAPI(client)
+		}
 	}
 	return client
 }

--- a/api.go
+++ b/api.go
@@ -56,7 +56,9 @@ func (c *APIClient) doRequest(ctx context.Context, verb, requestPath string, bod
 	if err != nil {
 		return nil, 0, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	respBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/api.go
+++ b/api.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -35,7 +35,7 @@ func NewAPIClient(key string, opts ...option) *APIClient {
 	return client
 }
 
-func (c *APIClient) doRequest(ctx context.Context, verb, requestPath string, body interface{}) ([]byte, int, error) {
+func (c *APIClient) doRequest(ctx context.Context, verb, requestPath string, body any) ([]byte, int, error) {
 	b, err := json.Marshal(body)
 	if err != nil {
 		return nil, 0, err
@@ -60,7 +60,7 @@ func (c *APIClient) doRequest(ctx context.Context, verb, requestPath string, bod
 		_ = resp.Body.Close()
 	}()
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/api.go
+++ b/api.go
@@ -24,7 +24,7 @@ type APIClient struct {
 func NewAPIClient(key string, opts ...Option) *APIClient {
 	client := &APIClient{
 		Key:       key,
-		Client:    http.DefaultClient,
+		Client:    newDefaultHTTPClient(),
 		URL:       "https://api.customer.io",
 		UserAgent: DefaultUserAgent,
 	}

--- a/api.go
+++ b/api.go
@@ -24,7 +24,7 @@ type APIClient struct {
 func NewAPIClient(key string, opts ...option) *APIClient {
 	client := &APIClient{
 		Key:       key,
-		Client:    http.DefaultClient,
+		Client:    newDefaultHTTPClient(),
 		URL:       "https://api.customer.io",
 		UserAgent: DefaultUserAgent,
 	}

--- a/api.go
+++ b/api.go
@@ -37,6 +37,9 @@ func NewAPIClient(key string, opts ...Option) *APIClient {
 	return client
 }
 
+// doRequest returns the raw response body and status code. Callers
+// must check the status code and handle errors; unlike CustomerIO.request(),
+// this method does not return an error for non-200 responses.
 func (c *APIClient) doRequest(ctx context.Context, verb, requestPath string, body any) ([]byte, int, error) {
 	b, err := json.Marshal(body)
 	if err != nil {
@@ -60,7 +63,7 @@ func (c *APIClient) doRequest(ctx context.Context, verb, requestPath string, bod
 		_ = resp.Body.Close()
 	}()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return nil, 0, err
 	}

--- a/customerio.go
+++ b/customerio.go
@@ -153,18 +153,17 @@ func (c *CustomerIO) request(ctx context.Context, method, url string, body inter
 			return err
 		}
 
-		req, err = http.NewRequest(method, url, bytes.NewBuffer(j))
+		req, err = http.NewRequestWithContext(ctx, method, url, bytes.NewBuffer(j))
 		if err != nil {
 			return err
 		}
-		req = req.WithContext(ctx)
 
 		req.Header.Add("User-Agent", c.UserAgent)
 		req.Header.Add("Content-Type", "application/json")
 		req.Header.Add("Content-Length", strconv.Itoa(len(j)))
 	} else {
 		var err error
-		req, err = http.NewRequest(method, url, nil)
+		req, err = http.NewRequestWithContext(ctx, method, url, nil)
 		if err != nil {
 			return err
 		}

--- a/customerio.go
+++ b/customerio.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -68,7 +68,7 @@ func NewCustomerIO(siteID, apiKey string) *CustomerIO {
 }
 
 // IdentifyCtx identifies a customer and sets their attributes
-func (c *CustomerIO) IdentifyCtx(ctx context.Context, customerID string, attributes map[string]interface{}) error {
+func (c *CustomerIO) IdentifyCtx(ctx context.Context, customerID string, attributes map[string]any) error {
 	if customerID == "" {
 		return ParamError{Param: "customerID"}
 	}
@@ -78,12 +78,12 @@ func (c *CustomerIO) IdentifyCtx(ctx context.Context, customerID string, attribu
 }
 
 // Identify identifies a customer and sets their attributes
-func (c *CustomerIO) Identify(customerID string, attributes map[string]interface{}) error {
+func (c *CustomerIO) Identify(customerID string, attributes map[string]any) error {
 	return c.IdentifyCtx(context.Background(), customerID, attributes)
 }
 
 // TrackCtx sends a single event to Customer.io for the supplied user
-func (c *CustomerIO) TrackCtx(ctx context.Context, customerID string, eventName string, data map[string]interface{}) error {
+func (c *CustomerIO) TrackCtx(ctx context.Context, customerID string, eventName string, data map[string]any) error {
 	if customerID == "" {
 		return ParamError{Param: "customerID"}
 	}
@@ -92,24 +92,24 @@ func (c *CustomerIO) TrackCtx(ctx context.Context, customerID string, eventName 
 	}
 	return c.request(ctx, "POST",
 		fmt.Sprintf("%s/api/v1/customers/%s/events", c.URL, url.PathEscape(customerID)),
-		map[string]interface{}{
+		map[string]any{
 			"name": eventName,
 			"data": data,
 		})
 }
 
 // Track sends a single event to Customer.io for the supplied user
-func (c *CustomerIO) Track(customerID string, eventName string, data map[string]interface{}) error {
+func (c *CustomerIO) Track(customerID string, eventName string, data map[string]any) error {
 	return c.TrackCtx(context.Background(), customerID, eventName, data)
 }
 
 // TrackAnonymousCtx sends a single event to Customer.io for the anonymous user
-func (c *CustomerIO) TrackAnonymousCtx(ctx context.Context, anonymousID, eventName string, data map[string]interface{}) error {
+func (c *CustomerIO) TrackAnonymousCtx(ctx context.Context, anonymousID, eventName string, data map[string]any) error {
 	if eventName == "" {
 		return ParamError{Param: "eventName"}
 	}
 
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"name": eventName,
 		"data": data,
 	}
@@ -122,7 +122,7 @@ func (c *CustomerIO) TrackAnonymousCtx(ctx context.Context, anonymousID, eventNa
 }
 
 // TrackAnonymous sends a single event to Customer.io for the anonymous user
-func (c *CustomerIO) TrackAnonymous(anonymousID, eventName string, data map[string]interface{}) error {
+func (c *CustomerIO) TrackAnonymous(anonymousID, eventName string, data map[string]any) error {
 	return c.TrackAnonymousCtx(context.Background(), anonymousID, eventName, data)
 }
 
@@ -140,7 +140,7 @@ func (c *CustomerIO) auth() string {
 	return base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%v:%v", c.siteID, c.apiKey)))
 }
 
-func (c *CustomerIO) request(ctx context.Context, method, url string, body interface{}) error {
+func (c *CustomerIO) request(ctx context.Context, method, url string, body any) error {
 	var req *http.Request
 	if body != nil {
 		j, err := json.Marshal(body)
@@ -174,7 +174,7 @@ func (c *CustomerIO) request(ctx context.Context, method, url string, body inter
 		_ = resp.Body.Close()
 	}()
 
-	responseBody, err := ioutil.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -234,7 +234,7 @@ func (c *CustomerIO) MergeCustomersCtx(ctx context.Context, primary Identifier, 
 
 	return c.request(ctx, "POST",
 		fmt.Sprintf("%s/api/v1/merge_customers", c.URL),
-		map[string]interface{}{
+		map[string]any{
 			"primary":   primary.kv(),
 			"secondary": secondary.kv(),
 		})

--- a/customerio.go
+++ b/customerio.go
@@ -46,17 +46,12 @@ func (e ParamError) Error() string { return e.Param + ": missing" }
 // NewTrackClient prepares a client for use with the Customer.io track API, see: https://customer.io/docs/api/#apitrackintroduction
 // using a Tracking Site ID and API Key pair from https://fly.customer.io/settings/api_credentials
 func NewTrackClient(siteID, apiKey string, opts ...option) *CustomerIO {
-	client := &http.Client{
-		Transport: &http.Transport{
-			MaxIdleConnsPerHost: 100,
-		},
-	}
 	c := &CustomerIO{
 		siteID:    siteID,
 		apiKey:    apiKey,
 		URL:       "https://track.customer.io",
 		UserAgent: DefaultUserAgent,
-		Client:    client,
+		Client:    newDefaultHTTPClient(),
 	}
 
 	for _, opt := range opts {

--- a/customerio.go
+++ b/customerio.go
@@ -36,6 +36,23 @@ func (e *CustomerIOError) Error() string {
 	return fmt.Sprintf("%v: %v %v", e.status, e.url, string(e.body))
 }
 
+// StatusCode returns the HTTP status code from a failed API response.
+func (e *CustomerIOError) StatusCode() int {
+	return e.status
+}
+
+// URL returns the request URL from a failed API response.
+func (e *CustomerIOError) URL() string {
+	return e.url
+}
+
+// Body returns a copy of the failed API response body.
+func (e *CustomerIOError) Body() []byte {
+	body := make([]byte, len(e.body))
+	copy(body, e.body)
+	return body
+}
+
 // ParamError is an error returned if a parameter to the track API is invalid.
 type ParamError struct {
 	Param string // Param is the name of the parameter.
@@ -45,7 +62,7 @@ func (e ParamError) Error() string { return e.Param + ": missing" }
 
 // NewTrackClient prepares a client for use with the Customer.io track API, see: https://customer.io/docs/api/#apitrackintroduction
 // using a Tracking Site ID and API Key pair from https://fly.customer.io/settings/api_credentials
-func NewTrackClient(siteID, apiKey string, opts ...option) *CustomerIO {
+func NewTrackClient(siteID, apiKey string, opts ...Option) *CustomerIO {
 	c := &CustomerIO{
 		siteID:    siteID,
 		apiKey:    apiKey,
@@ -62,7 +79,8 @@ func NewTrackClient(siteID, apiKey string, opts ...option) *CustomerIO {
 }
 
 // NewCustomerIO prepares a client for use with the Customer.io track API, see: https://customer.io/docs/api/#apitrackintroduction
-// deprecated in favour of NewTrackClient
+//
+// Deprecated: use NewTrackClient.
 func NewCustomerIO(siteID, apiKey string) *CustomerIO {
 	return NewTrackClient(siteID, apiKey)
 }

--- a/customerio.go
+++ b/customerio.go
@@ -72,7 +72,10 @@ func NewTrackClient(siteID, apiKey string, opts ...Option) *CustomerIO {
 	}
 
 	for _, opt := range opts {
-		opt.track(c)
+		if opt == nil {
+			continue
+		}
+		opt.applyTrack(c)
 	}
 
 	return c
@@ -149,7 +152,7 @@ func (c *CustomerIO) DeleteCtx(ctx context.Context, customerID string) error {
 }
 
 func (c *CustomerIO) auth() string {
-	return base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%v:%v", c.siteID, c.apiKey)))
+	return base64.URLEncoding.EncodeToString(fmt.Appendf(nil, "%v:%v", c.siteID, c.apiKey))
 }
 
 func (c *CustomerIO) request(ctx context.Context, method, url string, body any) error {

--- a/customerio.go
+++ b/customerio.go
@@ -170,7 +170,9 @@ func (c *CustomerIO) request(ctx context.Context, method, url string, body inter
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	responseBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -208,9 +210,9 @@ func (id Identifier) kv() map[string]string {
 }
 
 func (id Identifier) validate() error {
-	if !(id.Type == IdentifierTypeID ||
-		id.Type == IdentifierTypeEmail ||
-		id.Type == IdentifierTypeCioID) {
+	if id.Type != IdentifierTypeID &&
+		id.Type != IdentifierTypeEmail &&
+		id.Type != IdentifierTypeCioID {
 		return errors.New("invalid id type")
 	}
 

--- a/customerio.go
+++ b/customerio.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 )
 
@@ -170,7 +169,6 @@ func (c *CustomerIO) request(ctx context.Context, method, url string, body any) 
 
 		req.Header.Add("User-Agent", c.UserAgent)
 		req.Header.Add("Content-Type", "application/json")
-		req.Header.Add("Content-Length", strconv.Itoa(len(j)))
 	} else {
 		var err error
 		req, err = http.NewRequestWithContext(ctx, method, url, nil)
@@ -189,7 +187,7 @@ func (c *CustomerIO) request(ctx context.Context, method, url string, body any) 
 		_ = resp.Body.Close()
 	}()
 
-	responseBody, err := io.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return err
 	}
@@ -240,11 +238,11 @@ func (id Identifier) validate() error {
 
 // MergeCustomersCtx sends a request to Customer.io to merge two customer profiles together.
 func (c *CustomerIO) MergeCustomersCtx(ctx context.Context, primary Identifier, secondary Identifier) error {
-	if primary.validate() != nil {
-		return ParamError{Param: "primary"}
+	if err := primary.validate(); err != nil {
+		return fmt.Errorf("primary: %w", err)
 	}
-	if secondary.validate() != nil {
-		return ParamError{Param: "secondary"}
+	if err := secondary.validate(); err != nil {
+		return fmt.Errorf("secondary: %w", err)
 	}
 
 	return c.request(ctx, "POST",

--- a/customerio.go
+++ b/customerio.go
@@ -142,7 +142,7 @@ func (c *CustomerIO) DeleteCtx(ctx context.Context, customerID string) error {
 }
 
 func (c *CustomerIO) auth() string {
-	return base64.URLEncoding.EncodeToString([]byte(fmt.Sprintf("%v:%v", c.siteID, c.apiKey)))
+	return base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%v:%v", c.siteID, c.apiKey)))
 }
 
 func (c *CustomerIO) request(ctx context.Context, method, url string, body interface{}) error {

--- a/customerio_test.go
+++ b/customerio_test.go
@@ -77,6 +77,29 @@ func TestIdentify(t *testing.T) {
 		})
 }
 
+func TestBasicAuthUsesStandardBase64(t *testing.T) {
+	siteID := "~~~"
+	apiKey := "~~~"
+	expectedAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte(siteID+":"+apiKey))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if got := req.Header.Get("Authorization"); got != expectedAuth {
+			t.Errorf("expected Authorization %q got %q", expectedAuth, got)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := customerio.NewTrackClient(siteID, apiKey)
+	client.URL = srv.URL
+
+	if err := client.Identify("1", map[string]interface{}{"a": "1"}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestTrack(t *testing.T) {
 	data := map[string]interface{}{
 		"a": "1",

--- a/customerio_test.go
+++ b/customerio_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -40,7 +39,7 @@ type testCase struct {
 	id     string
 	method string
 	path   string
-	body   interface{}
+	body   any
 }
 
 func runCases(t *testing.T, cases []testCase, do func(c testCase) error) {
@@ -68,7 +67,7 @@ func checkParamError(t *testing.T, err error, param string) {
 }
 
 func TestIdentify(t *testing.T) {
-	attributes := map[string]interface{}{
+	attributes := map[string]any{
 		"a": "1",
 	}
 	err := cio.Identify("", attributes)
@@ -103,19 +102,19 @@ func TestBasicAuthUsesStandardBase64(t *testing.T) {
 	client := customerio.NewTrackClient(siteID, apiKey)
 	client.URL = srv.URL
 
-	if err := client.Identify("1", map[string]interface{}{"a": "1"}); err != nil {
+	if err := client.Identify("1", map[string]any{"a": "1"}); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestTrack(t *testing.T) {
-	data := map[string]interface{}{
+	data := map[string]any{
 		"a": "1",
 	}
 
-	body := map[string]interface{}{
+	body := map[string]any{
 		"name": "test",
-		"data": map[string]interface{}{
+		"data": map[string]any{
 			"a": "1",
 		},
 	}
@@ -136,14 +135,14 @@ func TestTrack(t *testing.T) {
 }
 
 func TestTrackAnonymous(t *testing.T) {
-	data := map[string]interface{}{
+	data := map[string]any{
 		"a": "1",
 	}
 
-	body := map[string]interface{}{
+	body := map[string]any{
 		"name":         "test",
 		"anonymous_id": "anon123",
-		"data": map[string]interface{}{
+		"data": map[string]any{
 			"a": "1",
 		},
 	}
@@ -195,7 +194,7 @@ func TestAddDevice(t *testing.T) {
 	err = cio.AddDevice("1", "d1", "", nil)
 	checkParamError(t, err, "platform")
 
-	body := map[string]map[string]interface{}{
+	body := map[string]map[string]any{
 		"device": {
 			"id":        "d1",
 			"platform":  "ios",
@@ -209,7 +208,7 @@ func TestAddDevice(t *testing.T) {
 			{"1/", "PUT", "/api/v1/customers/1%2F/devices", body},
 		},
 		func(c testCase) error {
-			return cio.AddDevice(c.id, "d1", "ios", map[string]interface{}{
+			return cio.AddDevice(c.id, "d1", "ios", map[string]any{
 				"last_used": 1606511962,
 			})
 		})
@@ -243,11 +242,11 @@ func TestDeleteDevice(t *testing.T) {
 var (
 	expectedMethod string
 	expectedPath   string
-	expectedBody   interface{}
+	expectedBody   any
 )
 
 func handler(w http.ResponseWriter, req *http.Request) {
-	b, err := ioutil.ReadAll(req.Body)
+	b, err := io.ReadAll(req.Body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -281,7 +280,7 @@ func handler(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "expected Content-Type application/json", http.StatusBadRequest)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if len(b) > 0 {
 		dec := json.NewDecoder(bytes.NewReader(b))
 		dec.UseNumber()
@@ -290,7 +289,7 @@ func handler(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 	}
-	validate := func(method, path string, body interface{}) error {
+	validate := func(method, path string, body any) error {
 		if method != expectedMethod {
 			return fmt.Errorf("expected %s got %s", expectedMethod, method)
 		}
@@ -317,7 +316,7 @@ func handler(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func expect(method, path string, body interface{}) {
+func expect(method, path string, body any) {
 	expectedMethod = method
 	expectedPath = path
 	expectedBody = body

--- a/customerio_test.go
+++ b/customerio_test.go
@@ -2,9 +2,11 @@ package customerio_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +19,12 @@ import (
 )
 
 var cio *customerio.CustomerIO
+
+type httpClientFunc func(*http.Request) (*http.Response, error)
+
+func (f httpClientFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestMain(m *testing.M) {
 	srv := httptest.NewServer(http.HandlerFunc(handler))
@@ -158,6 +166,25 @@ func TestDelete(t *testing.T) {
 		func(c testCase) error {
 			return cio.Delete(c.id)
 		})
+}
+
+func TestDeleteCtxUsesRequestContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	client := customerio.NewTrackClient("siteid", "apikey", customerio.WithHTTPClient(httpClientFunc(func(req *http.Request) (*http.Response, error) {
+		if err := req.Context().Err(); err != context.Canceled {
+			t.Errorf("expected canceled request context, got %v", err)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	})))
+
+	if err := client.DeleteCtx(ctx, "1"); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestAddDevice(t *testing.T) {

--- a/customerio_test.go
+++ b/customerio_test.go
@@ -86,10 +86,10 @@ func TestIdentify(t *testing.T) {
 		})
 }
 
-func TestBasicAuthUsesStandardBase64(t *testing.T) {
+func TestBasicAuthUsesURLSafeBase64(t *testing.T) {
 	siteID := "~~~"
 	apiKey := "~~~"
-	expectedAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte(siteID+":"+apiKey))
+	expectedAuth := "Basic " + base64.URLEncoding.EncodeToString([]byte(siteID+":"+apiKey))
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if got := req.Header.Get("Authorization"); got != expectedAuth {
@@ -184,6 +184,24 @@ func TestTrackAnonymous(t *testing.T) {
 	}
 }
 
+func TestTrackAnonymousAllowsEmptyAnonymousID(t *testing.T) {
+	data := map[string]any{
+		"a": "1",
+	}
+
+	body := map[string]any{
+		"name": "test",
+		"data": map[string]any{
+			"a": "1",
+		},
+	}
+
+	expect("POST", "/api/v1/events", body)
+	if err := cio.TrackAnonymous("", "test", data); err != nil {
+		t.Error(err.Error())
+	}
+}
+
 func TestTrackAnonymousWithOptions(t *testing.T) {
 	data := map[string]any{
 		"a": "1",
@@ -247,6 +265,25 @@ func TestDeleteCtxUsesRequestContext(t *testing.T) {
 	}
 }
 
+func TestTrackCtxUsesRequestContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	client := customerio.NewTrackClient("siteid", "apikey", customerio.WithHTTPClient(httpClientFunc(func(req *http.Request) (*http.Response, error) {
+		if err := req.Context().Err(); err != context.Canceled {
+			t.Errorf("expected canceled request context, got %v", err)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	})))
+
+	if err := client.TrackCtx(ctx, "1", "purchase", nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestCustomerIOErrorAccessors(t *testing.T) {
 	const responseBody = "rate limited"
 
@@ -272,6 +309,9 @@ func TestCustomerIOErrorAccessors(t *testing.T) {
 	if apiErr.URL() != srv.URL+"/api/v1/customers/1/events" {
 		t.Errorf("unexpected url: %s", apiErr.URL())
 	}
+	if apiErr.Error() != fmt.Sprintf("%d: %s %s", http.StatusTooManyRequests, srv.URL+"/api/v1/customers/1/events", responseBody) {
+		t.Errorf("unexpected error string: %s", apiErr.Error())
+	}
 	body := apiErr.Body()
 	if string(body) != responseBody {
 		t.Errorf("expected body %q got %q", responseBody, string(body))
@@ -279,6 +319,29 @@ func TestCustomerIOErrorAccessors(t *testing.T) {
 	body[0] = 'R'
 	if string(apiErr.Body()) != responseBody {
 		t.Error("Body should return a copy")
+	}
+}
+
+func TestNewDeviceMarshalsToken(t *testing.T) {
+	device, err := customerio.NewDevice("device-id", "ios", map[string]any{"attr1": "value1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := json.Marshal(device)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(b, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload["token"] != "device-id" {
+		t.Errorf("expected token to be device-id, got %v", payload["token"])
+	}
+	if _, ok := payload["id"]; ok {
+		t.Errorf("device payload should use token, got id in %s", b)
 	}
 }
 
@@ -357,7 +420,7 @@ func handler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	decoded, err := base64.StdEncoding.DecodeString(s[1])
+	decoded, err := base64.URLEncoding.DecodeString(s[1])
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
 		return
@@ -367,7 +430,7 @@ func handler(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 		return
 	}
-	if pair[0] != "siteid" && pair[1] != "apikey" {
+	if pair[0] != "siteid" || pair[1] != "apikey" {
 		w.WriteHeader(http.StatusUnauthorized)
 		return
 	}
@@ -416,6 +479,38 @@ func expect(method, path string, body any) {
 	expectedMethod = method
 	expectedPath = path
 	expectedBody = body
+}
+
+func TestHandlerRejectsMismatchedBasicAuth(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		siteID string
+		apiKey string
+	}{
+		{
+			name:   "wrong site id",
+			siteID: "wrong",
+			apiKey: "apikey",
+		},
+		{
+			name:   "wrong api key",
+			siteID: "siteid",
+			apiKey: "wrong",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPut, "/api/v1/customers/1", strings.NewReader(`{"a":"1"}`))
+			req.Header.Set("Authorization", "Basic "+base64.URLEncoding.EncodeToString([]byte(tc.siteID+":"+tc.apiKey)))
+			req.Header.Set("Content-Type", "application/json")
+
+			rec := httptest.NewRecorder()
+			handler(rec, req)
+
+			if rec.Code != http.StatusUnauthorized {
+				t.Errorf("expected status %d got %d", http.StatusUnauthorized, rec.Code)
+			}
+		})
+	}
 }
 
 func TestMergeCustomers(t *testing.T) {

--- a/customerio_test.go
+++ b/customerio_test.go
@@ -514,6 +514,16 @@ func TestHandlerRejectsMismatchedBasicAuth(t *testing.T) {
 }
 
 func TestMergeCustomers(t *testing.T) {
+	checkMergeError := func(t *testing.T, err error, prefix, contains string) {
+		t.Helper()
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if got := err.Error(); !strings.Contains(got, prefix+": ") || !strings.Contains(got, contains) {
+			t.Errorf("expected error containing %q and %q, got %q", prefix, contains, got)
+		}
+	}
+
 	err1 := cio.MergeCustomers(customerio.Identifier{
 		Type:  "",
 		Value: "id1",
@@ -521,7 +531,7 @@ func TestMergeCustomers(t *testing.T) {
 		Type:  "id",
 		Value: "id2",
 	})
-	checkParamError(t, err1, "primary")
+	checkMergeError(t, err1, "primary", "invalid id type")
 
 	err2 := cio.MergeCustomers(customerio.Identifier{
 		Type:  "id",
@@ -530,7 +540,7 @@ func TestMergeCustomers(t *testing.T) {
 		Type:  "id",
 		Value: "id2",
 	})
-	checkParamError(t, err2, "primary")
+	checkMergeError(t, err2, "primary", "invalid id")
 
 	err3 := cio.MergeCustomers(customerio.Identifier{
 		Type:  "email",
@@ -539,7 +549,7 @@ func TestMergeCustomers(t *testing.T) {
 		Type:  "",
 		Value: "id2",
 	})
-	checkParamError(t, err3, "secondary")
+	checkMergeError(t, err3, "secondary", "invalid id type")
 
 	err4 := cio.MergeCustomers(customerio.Identifier{
 		Type:  "cio_id",
@@ -548,7 +558,7 @@ func TestMergeCustomers(t *testing.T) {
 		Type:  "email",
 		Value: "",
 	})
-	checkParamError(t, err4, "secondary")
+	checkMergeError(t, err4, "secondary", "invalid id")
 
 	runCases(t,
 		[]testCase{

--- a/customerio_test.go
+++ b/customerio_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -183,6 +184,41 @@ func TestDeleteCtxUsesRequestContext(t *testing.T) {
 
 	if err := client.DeleteCtx(ctx, "1"); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestCustomerIOErrorAccessors(t *testing.T) {
+	const responseBody = "rate limited"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		if _, err := w.Write([]byte(responseBody)); err != nil {
+			t.Error(err)
+		}
+	}))
+	defer srv.Close()
+
+	client := customerio.NewTrackClient("siteid", "apikey")
+	client.URL = srv.URL
+
+	err := client.Track("1", "purchase", nil)
+	var apiErr *customerio.CustomerIOError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected CustomerIOError, got %T", err)
+	}
+	if apiErr.StatusCode() != http.StatusTooManyRequests {
+		t.Errorf("expected status %d got %d", http.StatusTooManyRequests, apiErr.StatusCode())
+	}
+	if apiErr.URL() != srv.URL+"/api/v1/customers/1/events" {
+		t.Errorf("unexpected url: %s", apiErr.URL())
+	}
+	body := apiErr.Body()
+	if string(body) != responseBody {
+		t.Errorf("expected body %q got %q", responseBody, string(body))
+	}
+	body[0] = 'R'
+	if string(apiErr.Body()) != responseBody {
+		t.Error("Body should return a copy")
 	}
 }
 

--- a/customerio_test.go
+++ b/customerio_test.go
@@ -252,7 +252,9 @@ func handler(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	defer req.Body.Close()
+	defer func() {
+		_ = req.Body.Close()
+	}()
 
 	s := strings.SplitN(req.Header.Get("Authorization"), " ", 2)
 	if len(s) != 2 || s[0] != "Basic" {
@@ -303,7 +305,7 @@ func handler(w http.ResponseWriter, req *http.Request) {
 		if err != nil {
 			return err
 		}
-		if bytes.Compare(expected, got) != 0 {
+		if !bytes.Equal(expected, got) {
 			return fmt.Errorf("expected %v got %v", expected, got)
 		}
 		return nil
@@ -365,7 +367,8 @@ func TestMergeCustomers(t *testing.T) {
 			{"3", "POST", "/api/v1/merge_customers", `{"primary":{"cio_id":"CIO123"},"secondary":{"id":"person1"}}`},
 		},
 		func(c testCase) error {
-			if c.id == "1" {
+			switch c.id {
+			case "1":
 				return cio.MergeCustomers(customerio.Identifier{
 					Type:  "email",
 					Value: "cool.person@company.com",
@@ -373,7 +376,7 @@ func TestMergeCustomers(t *testing.T) {
 					Type:  "email",
 					Value: "cperson@gmail.com",
 				})
-			} else if c.id == "2" {
+			case "2":
 				return cio.MergeCustomers(customerio.Identifier{
 					Type:  "id",
 					Value: "cool.person@company.com",
@@ -381,7 +384,7 @@ func TestMergeCustomers(t *testing.T) {
 					Type:  "cio_id",
 					Value: "person2",
 				})
-			} else {
+			default:
 				return cio.MergeCustomers(customerio.Identifier{
 					Type:  customerio.IdentifierTypeCioID,
 					Value: "CIO123",

--- a/device.go
+++ b/device.go
@@ -15,7 +15,7 @@ type deviceV1 struct {
 
 // Device identifies a push notification device for transactional sends.
 type Device struct {
-	ID         string         `json:"token"`
+	Token      string         `json:"token"`
 	Platform   string         `json:"platform"`
 	LastUsed   string         `json:"last_used,omitempty"`
 	Attributes map[string]any `json:"attributes"`
@@ -55,7 +55,7 @@ func NewDevice(deviceID, platform string, data map[string]any) (*Device, error) 
 		return nil, err
 	}
 	return &Device{
-		ID:         d.ID,
+		Token:      d.ID,
 		Platform:   d.Platform,
 		Attributes: d.Attributes,
 		LastUsed:   d.LastUsed,

--- a/device.go
+++ b/device.go
@@ -13,7 +13,8 @@ type deviceV1 struct {
 	Attributes map[string]any `json:"attributes"`
 }
 
-type deviceV2 struct {
+// Device identifies a push notification device for transactional sends.
+type Device struct {
 	ID         string         `json:"token"`
 	Platform   string         `json:"platform"`
 	LastUsed   string         `json:"last_used,omitempty"`
@@ -47,12 +48,13 @@ func newDeviceV1(deviceID, platform string, data map[string]any) (*deviceV1, err
 	return d, nil
 }
 
-func NewDevice(deviceID, platform string, data map[string]any) (*deviceV2, error) {
+// NewDevice prepares a push notification device for transactional sends.
+func NewDevice(deviceID, platform string, data map[string]any) (*Device, error) {
 	d, err := newDeviceV1(deviceID, platform, data)
 	if err != nil {
 		return nil, err
 	}
-	return &deviceV2{
+	return &Device{
 		ID:         d.ID,
 		Platform:   d.Platform,
 		Attributes: d.Attributes,

--- a/device.go
+++ b/device.go
@@ -7,20 +7,20 @@ import (
 )
 
 type deviceV1 struct {
-	ID         string                 `json:"id"`
-	Platform   string                 `json:"platform"`
-	LastUsed   string                 `json:"last_used,omitempty"`
-	Attributes map[string]interface{} `json:"attributes"`
+	ID         string         `json:"id"`
+	Platform   string         `json:"platform"`
+	LastUsed   string         `json:"last_used,omitempty"`
+	Attributes map[string]any `json:"attributes"`
 }
 
 type deviceV2 struct {
-	ID         string                 `json:"token"`
-	Platform   string                 `json:"platform"`
-	LastUsed   string                 `json:"last_used,omitempty"`
-	Attributes map[string]interface{} `json:"attributes"`
+	ID         string         `json:"token"`
+	Platform   string         `json:"platform"`
+	LastUsed   string         `json:"last_used,omitempty"`
+	Attributes map[string]any `json:"attributes"`
 }
 
-func newDeviceV1(deviceID, platform string, data map[string]interface{}) (*deviceV1, error) {
+func newDeviceV1(deviceID, platform string, data map[string]any) (*deviceV1, error) {
 	if deviceID == "" {
 		return nil, ParamError{Param: "deviceID"}
 	}
@@ -33,7 +33,7 @@ func newDeviceV1(deviceID, platform string, data map[string]interface{}) (*devic
 	}
 
 	if len(data) > 0 {
-		d.Attributes = make(map[string]interface{})
+		d.Attributes = make(map[string]any)
 	}
 
 	for k, v := range data {
@@ -47,7 +47,7 @@ func newDeviceV1(deviceID, platform string, data map[string]interface{}) (*devic
 	return d, nil
 }
 
-func NewDevice(deviceID, platform string, data map[string]interface{}) (*deviceV2, error) {
+func NewDevice(deviceID, platform string, data map[string]any) (*deviceV2, error) {
 	d, err := newDeviceV1(deviceID, platform, data)
 	if err != nil {
 		return nil, err
@@ -66,7 +66,7 @@ func (c *CustomerIO) Delete(customerID string) error {
 }
 
 // AddDeviceCtx adds a device for a customer
-func (c *CustomerIO) AddDeviceCtx(ctx context.Context, customerID string, deviceID string, platform string, data map[string]interface{}) error {
+func (c *CustomerIO) AddDeviceCtx(ctx context.Context, customerID string, deviceID string, platform string, data map[string]any) error {
 	if customerID == "" {
 		return ParamError{Param: "customerID"}
 	}
@@ -76,7 +76,7 @@ func (c *CustomerIO) AddDeviceCtx(ctx context.Context, customerID string, device
 		return err
 	}
 
-	body := map[string]interface{}{
+	body := map[string]any{
 		"device": d,
 	}
 
@@ -86,7 +86,7 @@ func (c *CustomerIO) AddDeviceCtx(ctx context.Context, customerID string, device
 }
 
 // AddDevice adds a device for a customer
-func (c *CustomerIO) AddDevice(customerID string, deviceID string, platform string, data map[string]interface{}) error {
+func (c *CustomerIO) AddDevice(customerID string, deviceID string, platform string, data map[string]any) error {
 	return c.AddDeviceCtx(context.Background(), customerID, deviceID, platform, data)
 }
 

--- a/examples/transactional.go
+++ b/examples/transactional.go
@@ -22,7 +22,7 @@ func main() {
 		From:    "business@example.com",
 		Subject: "hello, {{ trigger.name }}",
 		Body:    "hello from the Customer.io {{ trigger.client }} client",
-		MessageData: map[string]interface{}{
+		MessageData: map[string]any{
 			"client": "Go",
 			"name":   "gopher",
 		},

--- a/examples/transactional.go
+++ b/examples/transactional.go
@@ -32,7 +32,9 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	if err := emailReq.Attach("sample.pdf", f); err != nil {
 		panic(err)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/customerio/go-customerio/v3
 
-go 1.17
+go 1.21

--- a/http.go
+++ b/http.go
@@ -2,21 +2,21 @@ package customerio
 
 import (
 	"net/http"
-	"time"
 )
-
-// DefaultHTTPTimeout is the timeout used by clients created without WithHTTPClient.
-const DefaultHTTPTimeout = 30 * time.Second
 
 func newDefaultHTTPClient() *http.Client {
 	return &http.Client{
-		Timeout:   DefaultHTTPTimeout,
 		Transport: newDefaultTransport(),
 	}
 }
 
-func newDefaultTransport() *http.Transport {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+func newDefaultTransport() http.RoundTripper {
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return http.DefaultTransport
+	}
+
+	transport = transport.Clone()
 	transport.MaxIdleConnsPerHost = 100
 	return transport
 }

--- a/http.go
+++ b/http.go
@@ -5,7 +5,9 @@ import (
 	"time"
 )
 
-// DefaultHTTPTimeout is the timeout used by clients created without WithHTTPClient.
+// DefaultHTTPTimeout is the timeout used by clients created without
+// WithHTTPClient. For requests with large attachments, you may need
+// a longer timeout via WithHTTPClient.
 const DefaultHTTPTimeout = 30 * time.Second
 
 func newDefaultHTTPClient() *http.Client {
@@ -18,6 +20,8 @@ func newDefaultHTTPClient() *http.Client {
 func newDefaultTransport() http.RoundTripper {
 	transport, ok := http.DefaultTransport.(*http.Transport)
 	if !ok {
+		// Non-*http.Transport (e.g. OpenTelemetry instrumented transport).
+		// Return as-is; MaxIdleConnsPerHost tuning is skipped.
 		return http.DefaultTransport
 	}
 

--- a/http.go
+++ b/http.go
@@ -1,0 +1,21 @@
+package customerio
+
+import (
+	"net/http"
+	"time"
+)
+
+const DefaultHTTPTimeout = 30 * time.Second
+
+func newDefaultHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout:   DefaultHTTPTimeout,
+		Transport: newDefaultTransport(),
+	}
+}
+
+func newDefaultTransport() *http.Transport {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConnsPerHost = 100
+	return transport
+}

--- a/http.go
+++ b/http.go
@@ -2,10 +2,15 @@ package customerio
 
 import (
 	"net/http"
+	"time"
 )
+
+// DefaultHTTPTimeout is the timeout used by clients created without WithHTTPClient.
+const DefaultHTTPTimeout = 30 * time.Second
 
 func newDefaultHTTPClient() *http.Client {
 	return &http.Client{
+		Timeout:   DefaultHTTPTimeout,
 		Transport: newDefaultTransport(),
 	}
 }

--- a/http.go
+++ b/http.go
@@ -5,6 +5,7 @@ import (
 	"time"
 )
 
+// DefaultHTTPTimeout is the timeout used by clients created without WithHTTPClient.
 const DefaultHTTPTimeout = 30 * time.Second
 
 func newDefaultHTTPClient() *http.Client {

--- a/options.go
+++ b/options.go
@@ -3,43 +3,65 @@ package customerio
 import "time"
 
 // Option configures Customer.io API and Track clients.
-type Option struct {
+type Option interface {
+	applyAPI(*APIClient)
+	applyTrack(*CustomerIO)
+}
+
+type option struct {
 	api   func(*APIClient)
 	track func(*CustomerIO)
 }
 
-// Region configures the Customer.io API endpoints for a workspace region.
-type Region struct {
-	ApiURL   string
-	TrackURL string
+func (o option) applyAPI(a *APIClient) {
+	if o.api != nil {
+		o.api(a)
+	}
 }
 
-var (
+func (o option) applyTrack(c *CustomerIO) {
+	if o.track != nil {
+		o.track(c)
+	}
+}
+
+// Region configures the Customer.io API endpoints for a workspace region.
+type Region string
+
+const (
 	// RegionUS configures clients for Customer.io US endpoints.
-	RegionUS = Region{
-		ApiURL:   "https://api.customer.io",
-		TrackURL: "https://track.customer.io",
-	}
+	RegionUS Region = "us"
 	// RegionEU configures clients for Customer.io EU endpoints.
-	RegionEU = Region{
-		ApiURL:   "https://api-eu.customer.io",
-		TrackURL: "https://track-eu.customer.io",
-	}
+	RegionEU Region = "eu"
 )
 
+func (r Region) APIURL() string {
+	if r == RegionEU {
+		return "https://api-eu.customer.io"
+	}
+	return "https://api.customer.io"
+}
+
+func (r Region) TrackURL() string {
+	if r == RegionEU {
+		return "https://track-eu.customer.io"
+	}
+	return "https://track.customer.io"
+}
+
 func WithRegion(r Region) Option {
-	return Option{
+	return option{
 		api: func(a *APIClient) {
-			a.URL = r.ApiURL
+			a.URL = r.APIURL()
 		},
 		track: func(c *CustomerIO) {
-			c.URL = r.TrackURL
+			c.URL = r.TrackURL()
 		},
 	}
 }
 
 func WithHTTPClient(client HTTPClient) Option {
-	return Option{
+	return option{
 		api: func(a *APIClient) {
 			a.Client = client
 		},
@@ -50,7 +72,7 @@ func WithHTTPClient(client HTTPClient) Option {
 }
 
 func WithUserAgent(ua string) Option {
-	return Option{
+	return option{
 		api: func(a *APIClient) {
 			a.UserAgent = ua
 		},

--- a/options.go
+++ b/options.go
@@ -1,6 +1,9 @@
 package customerio
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // Option configures Customer.io API and Track clients.
 type Option interface {
@@ -50,6 +53,11 @@ func (r Region) TrackURL() string {
 }
 
 func WithRegion(r Region) Option {
+	switch r {
+	case RegionUS, RegionEU:
+	default:
+		panic(fmt.Sprintf("customerio: unknown region %q", r))
+	}
 	return option{
 		api: func(a *APIClient) {
 			a.URL = r.APIURL()
@@ -61,6 +69,9 @@ func WithRegion(r Region) Option {
 }
 
 func WithHTTPClient(client HTTPClient) Option {
+	if client == nil {
+		panic("customerio: WithHTTPClient called with nil HTTPClient")
+	}
 	return option{
 		api: func(a *APIClient) {
 			a.Client = client
@@ -72,6 +83,9 @@ func WithHTTPClient(client HTTPClient) Option {
 }
 
 func WithUserAgent(ua string) Option {
+	if ua == "" {
+		panic("customerio: WithUserAgent called with empty string")
+	}
 	return option{
 		api: func(a *APIClient) {
 			a.UserAgent = ua
@@ -122,7 +136,9 @@ func trackPayload(eventName string, data map[string]any, opts ...TrackOption) ma
 	}
 
 	for _, opt := range opts {
-		opt(payload)
+		if opt != nil {
+			opt(payload)
+		}
 	}
 
 	return payload

--- a/options.go
+++ b/options.go
@@ -1,28 +1,32 @@
 package customerio
 
-type option struct {
+// Option configures Customer.io API and Track clients.
+type Option struct {
 	api   func(*APIClient)
 	track func(*CustomerIO)
 }
 
-type region struct {
+// Region configures the Customer.io API endpoints for a workspace region.
+type Region struct {
 	ApiURL   string
 	TrackURL string
 }
 
 var (
-	RegionUS = region{
+	// RegionUS configures clients for Customer.io US endpoints.
+	RegionUS = Region{
 		ApiURL:   "https://api.customer.io",
 		TrackURL: "https://track.customer.io",
 	}
-	RegionEU = region{
+	// RegionEU configures clients for Customer.io EU endpoints.
+	RegionEU = Region{
 		ApiURL:   "https://api-eu.customer.io",
 		TrackURL: "https://track-eu.customer.io",
 	}
 )
 
-func WithRegion(r region) option {
-	return option{
+func WithRegion(r Region) Option {
+	return Option{
 		api: func(a *APIClient) {
 			a.URL = r.ApiURL
 		},
@@ -32,8 +36,8 @@ func WithRegion(r region) option {
 	}
 }
 
-func WithHTTPClient(client HTTPClient) option {
-	return option{
+func WithHTTPClient(client HTTPClient) Option {
+	return Option{
 		api: func(a *APIClient) {
 			a.Client = client
 		},
@@ -43,8 +47,8 @@ func WithHTTPClient(client HTTPClient) option {
 	}
 }
 
-func WithUserAgent(ua string) option {
-	return option{
+func WithUserAgent(ua string) Option {
+	return Option{
 		api: func(a *APIClient) {
 			a.UserAgent = ua
 		},

--- a/options_test.go
+++ b/options_test.go
@@ -23,8 +23,19 @@ func TestAPIOptions(t *testing.T) {
 	if client.URL != customerio.RegionUS.APIURL() {
 		t.Errorf("wrong default url. got: %s, want: %s", client.URL, customerio.RegionUS.APIURL())
 	}
-	if client.Client != http.DefaultClient {
-		t.Errorf("wrong default http client. got: %#v, want: %#v", client.Client, http.DefaultClient)
+	defaultHTTPClient, ok := client.Client.(*http.Client)
+	if !ok {
+		t.Fatalf("expected default HTTP client to be *http.Client, got %T", client.Client)
+	}
+	if defaultHTTPClient.Timeout != customerio.DefaultHTTPTimeout {
+		t.Errorf("wrong default timeout. got: %s, want: %s", defaultHTTPClient.Timeout, customerio.DefaultHTTPTimeout)
+	}
+	defaultTransport, ok := defaultHTTPClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected default transport to be *http.Transport, got %T", defaultHTTPClient.Transport)
+	}
+	if defaultTransport.MaxIdleConnsPerHost != 100 {
+		t.Errorf("wrong default max idle conns per host. got: %d, want: 100", defaultTransport.MaxIdleConnsPerHost)
 	}
 
 	client = customerio.NewAPIClient("mykey", customerio.WithRegion(customerio.RegionEU))
@@ -55,8 +66,8 @@ func TestTrackOptions(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected default HTTP client to be *http.Client, got %T", client.Client)
 	}
-	if defaultHTTPClient.Timeout != 0 {
-		t.Errorf("wrong default timeout. got: %s, want: 0s", defaultHTTPClient.Timeout)
+	if defaultHTTPClient.Timeout != customerio.DefaultHTTPTimeout {
+		t.Errorf("wrong default timeout. got: %s, want: %s", defaultHTTPClient.Timeout, customerio.DefaultHTTPTimeout)
 	}
 	defaultTransport, ok := defaultHTTPClient.Transport.(*http.Transport)
 	if !ok {
@@ -113,5 +124,8 @@ func TestTrackDefaultClientAcceptsInstrumentedDefaultTransport(t *testing.T) {
 	}
 	if defaultHTTPClient.Transport != rt {
 		t.Errorf("wrong default transport. got: %#v, want: %#v", defaultHTTPClient.Transport, rt)
+	}
+	if defaultHTTPClient.Timeout != customerio.DefaultHTTPTimeout {
+		t.Errorf("wrong default timeout. got: %s, want: %s", defaultHTTPClient.Timeout, customerio.DefaultHTTPTimeout)
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -8,23 +8,28 @@ import (
 	"github.com/customerio/go-customerio/v3"
 )
 
+type stubRoundTripper struct{}
+
+func (stubRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       http.NoBody,
+	}, nil
+}
+
 func TestAPIOptions(t *testing.T) {
 
 	client := customerio.NewAPIClient("mykey")
-	if client.URL != customerio.RegionUS.ApiURL {
-		t.Errorf("wrong default url. got: %s, want: %s", client.URL, customerio.RegionUS.ApiURL)
+	if client.URL != customerio.RegionUS.APIURL() {
+		t.Errorf("wrong default url. got: %s, want: %s", client.URL, customerio.RegionUS.APIURL())
 	}
-	defaultHTTPClient, ok := client.Client.(*http.Client)
-	if !ok {
-		t.Fatalf("expected default HTTP client to be *http.Client, got %T", client.Client)
-	}
-	if defaultHTTPClient.Timeout != customerio.DefaultHTTPTimeout {
-		t.Errorf("wrong default timeout. got: %s, want: %s", defaultHTTPClient.Timeout, customerio.DefaultHTTPTimeout)
+	if client.Client != http.DefaultClient {
+		t.Errorf("wrong default http client. got: %#v, want: %#v", client.Client, http.DefaultClient)
 	}
 
 	client = customerio.NewAPIClient("mykey", customerio.WithRegion(customerio.RegionEU))
-	if client.URL != customerio.RegionEU.ApiURL {
-		t.Errorf("wrong url. got: %s, want: %s", client.URL, customerio.RegionEU.ApiURL)
+	if client.URL != customerio.RegionEU.APIURL() {
+		t.Errorf("wrong url. got: %s, want: %s", client.URL, customerio.RegionEU.APIURL())
 	}
 
 	hc := &http.Client{}
@@ -43,15 +48,15 @@ func TestAPIOptions(t *testing.T) {
 func TestTrackOptions(t *testing.T) {
 
 	client := customerio.NewTrackClient("site_id", "api_key")
-	if client.URL != customerio.RegionUS.TrackURL {
-		t.Errorf("wrong default url. got: %s, want: %s", client.URL, customerio.RegionUS.TrackURL)
+	if client.URL != customerio.RegionUS.TrackURL() {
+		t.Errorf("wrong default url. got: %s, want: %s", client.URL, customerio.RegionUS.TrackURL())
 	}
 	defaultHTTPClient, ok := client.Client.(*http.Client)
 	if !ok {
 		t.Fatalf("expected default HTTP client to be *http.Client, got %T", client.Client)
 	}
-	if defaultHTTPClient.Timeout != customerio.DefaultHTTPTimeout {
-		t.Errorf("wrong default timeout. got: %s, want: %s", defaultHTTPClient.Timeout, customerio.DefaultHTTPTimeout)
+	if defaultHTTPClient.Timeout != 0 {
+		t.Errorf("wrong default timeout. got: %s, want: 0s", defaultHTTPClient.Timeout)
 	}
 	defaultTransport, ok := defaultHTTPClient.Transport.(*http.Transport)
 	if !ok {
@@ -62,8 +67,8 @@ func TestTrackOptions(t *testing.T) {
 	}
 
 	client = customerio.NewTrackClient("site_id", "api_key", customerio.WithRegion(customerio.RegionEU))
-	if client.URL != customerio.RegionEU.TrackURL {
-		t.Errorf("wrong url. got: %s, want: %s", client.URL, customerio.RegionEU.TrackURL)
+	if client.URL != customerio.RegionEU.TrackURL() {
+		t.Errorf("wrong url. got: %s, want: %s", client.URL, customerio.RegionEU.TrackURL())
 	}
 
 	hc := &http.Client{}
@@ -76,5 +81,37 @@ func TestTrackOptions(t *testing.T) {
 	client = customerio.NewTrackClient("site_id", "api_key", customerio.WithUserAgent(customUserAgent))
 	if client.UserAgent != customUserAgent {
 		t.Errorf("wrong user-agent. got: %s, want: %s", client.UserAgent, customUserAgent)
+	}
+}
+
+func TestNilOptionIsIgnored(t *testing.T) {
+	var opt customerio.Option
+
+	api := customerio.NewAPIClient("mykey", opt)
+	if api.URL != customerio.RegionUS.APIURL() {
+		t.Errorf("wrong default api url. got: %s, want: %s", api.URL, customerio.RegionUS.APIURL())
+	}
+
+	track := customerio.NewTrackClient("site_id", "api_key", opt)
+	if track.URL != customerio.RegionUS.TrackURL() {
+		t.Errorf("wrong default track url. got: %s, want: %s", track.URL, customerio.RegionUS.TrackURL())
+	}
+}
+
+func TestTrackDefaultClientAcceptsInstrumentedDefaultTransport(t *testing.T) {
+	original := http.DefaultTransport
+	rt := stubRoundTripper{}
+	http.DefaultTransport = rt
+	t.Cleanup(func() {
+		http.DefaultTransport = original
+	})
+
+	client := customerio.NewTrackClient("site_id", "api_key")
+	defaultHTTPClient, ok := client.Client.(*http.Client)
+	if !ok {
+		t.Fatalf("expected default HTTP client to be *http.Client, got %T", client.Client)
+	}
+	if defaultHTTPClient.Transport != rt {
+		t.Errorf("wrong default transport. got: %#v, want: %#v", defaultHTTPClient.Transport, rt)
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -14,6 +14,13 @@ func TestAPIOptions(t *testing.T) {
 	if client.URL != customerio.RegionUS.ApiURL {
 		t.Errorf("wrong default url. got: %s, want: %s", client.URL, customerio.RegionUS.ApiURL)
 	}
+	defaultHTTPClient, ok := client.Client.(*http.Client)
+	if !ok {
+		t.Fatalf("expected default HTTP client to be *http.Client, got %T", client.Client)
+	}
+	if defaultHTTPClient.Timeout != customerio.DefaultHTTPTimeout {
+		t.Errorf("wrong default timeout. got: %s, want: %s", defaultHTTPClient.Timeout, customerio.DefaultHTTPTimeout)
+	}
 
 	client = customerio.NewAPIClient("mykey", customerio.WithRegion(customerio.RegionEU))
 	if client.URL != customerio.RegionEU.ApiURL {
@@ -38,6 +45,20 @@ func TestTrackOptions(t *testing.T) {
 	client := customerio.NewTrackClient("site_id", "api_key")
 	if client.URL != customerio.RegionUS.TrackURL {
 		t.Errorf("wrong default url. got: %s, want: %s", client.URL, customerio.RegionUS.TrackURL)
+	}
+	defaultHTTPClient, ok := client.Client.(*http.Client)
+	if !ok {
+		t.Fatalf("expected default HTTP client to be *http.Client, got %T", client.Client)
+	}
+	if defaultHTTPClient.Timeout != customerio.DefaultHTTPTimeout {
+		t.Errorf("wrong default timeout. got: %s, want: %s", defaultHTTPClient.Timeout, customerio.DefaultHTTPTimeout)
+	}
+	defaultTransport, ok := defaultHTTPClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected default transport to be *http.Transport, got %T", defaultHTTPClient.Transport)
+	}
+	if defaultTransport.MaxIdleConnsPerHost != 100 {
+		t.Errorf("wrong default max idle conns per host. got: %d, want: 100", defaultTransport.MaxIdleConnsPerHost)
 	}
 
 	client = customerio.NewTrackClient("site_id", "api_key", customerio.WithRegion(customerio.RegionEU))

--- a/send_email.go
+++ b/send_email.go
@@ -9,28 +9,28 @@ import (
 )
 
 type SendEmailRequest struct {
-	MessageData             map[string]interface{} `json:"message_data,omitempty"`
-	TransactionalMessageID  string                 `json:"transactional_message_id,omitempty"`
-	Identifiers             map[string]string      `json:"identifiers"`
-	Headers                 map[string]string      `json:"headers,omitempty"`
-	From                    string                 `json:"from,omitempty"`
-	To                      string                 `json:"to,omitempty"`
-	ReplyTo                 string                 `json:"reply_to,omitempty"`
-	BCC                     string                 `json:"bcc,omitempty"`
-	Subject                 string                 `json:"subject,omitempty"`
-	Preheader               string                 `json:"preheader,omitempty"`
-	Body                    string                 `json:"body,omitempty"`
-	PlaintextBody           string                 `json:"body_plain,omitempty"`
-	AMPBody                 string                 `json:"body_amp,omitempty"`
-	FakeBCC                 *bool                  `json:"fake_bcc,omitempty"`
-	Attachments             map[string]string      `json:"attachments,omitempty"`
-	DisableMessageRetention *bool                  `json:"disable_message_retention,omitempty"`
-	SendToUnsubscribed      *bool                  `json:"send_to_unsubscribed,omitempty"`
-	EnableTracking          *bool                  `json:"tracked,omitempty"`
-	QueueDraft              *bool                  `json:"queue_draft,omitempty"`
-	DisableCSSPreprocessing *bool                  `json:"disable_css_preprocessing,omitempty"`
-	SendAt                  *int64                 `json:"send_at,omitempty"`
-	Language                *string                `json:"language,omitempty"`
+	MessageData             map[string]any    `json:"message_data,omitempty"`
+	TransactionalMessageID  string            `json:"transactional_message_id,omitempty"`
+	Identifiers             map[string]string `json:"identifiers"`
+	Headers                 map[string]string `json:"headers,omitempty"`
+	From                    string            `json:"from,omitempty"`
+	To                      string            `json:"to,omitempty"`
+	ReplyTo                 string            `json:"reply_to,omitempty"`
+	BCC                     string            `json:"bcc,omitempty"`
+	Subject                 string            `json:"subject,omitempty"`
+	Preheader               string            `json:"preheader,omitempty"`
+	Body                    string            `json:"body,omitempty"`
+	PlaintextBody           string            `json:"body_plain,omitempty"`
+	AMPBody                 string            `json:"body_amp,omitempty"`
+	FakeBCC                 *bool             `json:"fake_bcc,omitempty"`
+	Attachments             map[string]string `json:"attachments,omitempty"`
+	DisableMessageRetention *bool             `json:"disable_message_retention,omitempty"`
+	SendToUnsubscribed      *bool             `json:"send_to_unsubscribed,omitempty"`
+	EnableTracking          *bool             `json:"tracked,omitempty"`
+	QueueDraft              *bool             `json:"queue_draft,omitempty"`
+	DisableCSSPreprocessing *bool             `json:"disable_css_preprocessing,omitempty"`
+	SendAt                  *int64            `json:"send_at,omitempty"`
+	Language                *string           `json:"language,omitempty"`
 }
 
 var ErrAttachmentExists = errors.New("attachment with this name already exists")

--- a/send_email_test.go
+++ b/send_email_test.go
@@ -21,7 +21,7 @@ func TestSendEmail(t *testing.T) {
 		From:    "business@example.com",
 		Subject: "hello, {{ trigger.name }}",
 		Body:    "hello from the Customer.io {{ trigger.client }} client",
-		MessageData: map[string]interface{}{
+		MessageData: map[string]any{
 			"client": "Go",
 			"name":   "gopher",
 		},
@@ -75,7 +75,7 @@ func TestSendEmailError(t *testing.T) {
 		From:    "business@example.com",
 		Subject: "hello, {{ trigger.name }}",
 		Body:    "hello from the Customer.io {{ trigger.client }} client",
-		MessageData: map[string]interface{}{
+		MessageData: map[string]any{
 			"client": "Go",
 			"name":   "gopher",
 		},

--- a/send_in_app.go
+++ b/send_in_app.go
@@ -5,13 +5,13 @@ import (
 )
 
 type SendInAppRequest struct {
-	MessageData             map[string]interface{} `json:"message_data,omitempty"`
-	TransactionalMessageID  string                 `json:"transactional_message_id,omitempty"`
-	Identifiers             map[string]string      `json:"identifiers"`
-	DisableMessageRetention *bool                  `json:"disable_message_retention,omitempty"`
-	QueueDraft              *bool                  `json:"queue_draft,omitempty"`
-	SendAt                  *int64                 `json:"send_at,omitempty"`
-	Language                *string                `json:"language,omitempty"`
+	MessageData             map[string]any    `json:"message_data,omitempty"`
+	TransactionalMessageID  string            `json:"transactional_message_id,omitempty"`
+	Identifiers             map[string]string `json:"identifiers"`
+	DisableMessageRetention *bool             `json:"disable_message_retention,omitempty"`
+	QueueDraft              *bool             `json:"queue_draft,omitempty"`
+	SendAt                  *int64            `json:"send_at,omitempty"`
+	Language                *string           `json:"language,omitempty"`
 }
 
 type SendInAppResponse struct {

--- a/send_in_app_test.go
+++ b/send_in_app_test.go
@@ -16,7 +16,7 @@ func TestSendInApp(t *testing.T) {
 		Identifiers: map[string]string{
 			"id": "customer_1",
 		},
-		MessageData: map[string]interface{}{
+		MessageData: map[string]any{
 			"token": "123456",
 		},
 	}

--- a/send_inbox_message.go
+++ b/send_inbox_message.go
@@ -5,13 +5,13 @@ import (
 )
 
 type SendInboxMessageRequest struct {
-	MessageData             map[string]interface{} `json:"message_data,omitempty"`
-	TransactionalMessageID  string                 `json:"transactional_message_id,omitempty"`
-	Identifiers             map[string]string      `json:"identifiers"`
-	DisableMessageRetention *bool                  `json:"disable_message_retention,omitempty"`
-	QueueDraft              *bool                  `json:"queue_draft,omitempty"`
-	SendAt                  *int64                 `json:"send_at,omitempty"`
-	Language                *string                `json:"language,omitempty"`
+	MessageData             map[string]any    `json:"message_data,omitempty"`
+	TransactionalMessageID  string            `json:"transactional_message_id,omitempty"`
+	Identifiers             map[string]string `json:"identifiers"`
+	DisableMessageRetention *bool             `json:"disable_message_retention,omitempty"`
+	QueueDraft              *bool             `json:"queue_draft,omitempty"`
+	SendAt                  *int64            `json:"send_at,omitempty"`
+	Language                *string           `json:"language,omitempty"`
 }
 
 type SendInboxMessageResponse struct {

--- a/send_inbox_message_test.go
+++ b/send_inbox_message_test.go
@@ -16,7 +16,7 @@ func TestSendInboxMessage(t *testing.T) {
 		Identifiers: map[string]string{
 			"id": "customer_1",
 		},
-		MessageData: map[string]interface{}{
+		MessageData: map[string]any{
 			"token": "123456",
 		},
 	}

--- a/send_push.go
+++ b/send_push.go
@@ -6,15 +6,15 @@ import (
 )
 
 type SendPushRequest struct {
-	MessageData             map[string]interface{} `json:"message_data,omitempty"`
-	TransactionalMessageID  string                 `json:"transactional_message_id,omitempty"`
-	Identifiers             map[string]string      `json:"identifiers"`
-	To                      string                 `json:"to,omitempty"`
-	DisableMessageRetention *bool                  `json:"disable_message_retention,omitempty"`
-	SendToUnsubscribed      *bool                  `json:"send_to_unsubscribed,omitempty"`
-	QueueDraft              *bool                  `json:"queue_draft,omitempty"`
-	SendAt                  *int64                 `json:"send_at,omitempty"`
-	Language                *string                `json:"language,omitempty"`
+	MessageData             map[string]any    `json:"message_data,omitempty"`
+	TransactionalMessageID  string            `json:"transactional_message_id,omitempty"`
+	Identifiers             map[string]string `json:"identifiers"`
+	To                      string            `json:"to,omitempty"`
+	DisableMessageRetention *bool             `json:"disable_message_retention,omitempty"`
+	SendToUnsubscribed      *bool             `json:"send_to_unsubscribed,omitempty"`
+	QueueDraft              *bool             `json:"queue_draft,omitempty"`
+	SendAt                  *int64            `json:"send_at,omitempty"`
+	Language                *string           `json:"language,omitempty"`
 
 	Title         string          `json:"title,omitempty"`
 	Message       string          `json:"message,omitempty"`

--- a/send_push.go
+++ b/send_push.go
@@ -22,7 +22,7 @@ type SendPushRequest struct {
 	Link          string          `json:"link,omitempty"`
 	CustomData    json.RawMessage `json:"custom_data,omitempty"`
 	CustomPayload json.RawMessage `json:"custom_payload,omitempty"`
-	Device        *deviceV2       `json:"custom_device,omitempty"`
+	Device        *Device         `json:"custom_device,omitempty"`
 	Sound         string          `json:"sound,omitempty"`
 }
 

--- a/send_push_test.go
+++ b/send_push_test.go
@@ -18,12 +18,12 @@ func TestSendPush(t *testing.T) {
 		To:      "customer@example.com",
 		Title:   "hello, {{ trigger.name }}",
 		Message: "hello from the Customer.io {{ trigger.client }} client",
-		MessageData: map[string]interface{}{
+		MessageData: map[string]any{
 			"client": "Go",
 			"name":   "gopher",
 		},
 	}
-	d, err := customerio.NewDevice("device-id", "ios", map[string]interface{}{"attr1": "value1"})
+	d, err := customerio.NewDevice("device-id", "ios", map[string]any{"attr1": "value1"})
 	if err != nil {
 		t.Error(err)
 	}

--- a/send_sms.go
+++ b/send_sms.go
@@ -5,14 +5,14 @@ import (
 )
 
 type SendSMSRequest struct {
-	MessageData             map[string]interface{} `json:"message_data,omitempty"`
-	TransactionalMessageID  string                 `json:"transactional_message_id,omitempty"`
-	Identifiers             map[string]string      `json:"identifiers"`
-	DisableMessageRetention *bool                  `json:"disable_message_retention,omitempty"`
-	SendToUnsubscribed      *bool                  `json:"send_to_unsubscribed,omitempty"`
-	QueueDraft              *bool                  `json:"queue_draft,omitempty"`
-	SendAt                  *int64                 `json:"send_at,omitempty"`
-	Language                *string                `json:"language,omitempty"`
+	MessageData             map[string]any    `json:"message_data,omitempty"`
+	TransactionalMessageID  string            `json:"transactional_message_id,omitempty"`
+	Identifiers             map[string]string `json:"identifiers"`
+	DisableMessageRetention *bool             `json:"disable_message_retention,omitempty"`
+	SendToUnsubscribed      *bool             `json:"send_to_unsubscribed,omitempty"`
+	QueueDraft              *bool             `json:"queue_draft,omitempty"`
+	SendAt                  *int64            `json:"send_at,omitempty"`
+	Language                *string           `json:"language,omitempty"`
 
 	From string `json:"from,omitempty"`
 	To   string `json:"to,omitempty"`

--- a/send_sms_test.go
+++ b/send_sms_test.go
@@ -18,7 +18,7 @@ func TestSendSMS(t *testing.T) {
 		},
 		To:   "+12345678900",
 		From: "+18007654321",
-		MessageData: map[string]interface{}{
+		MessageData: map[string]any{
 			"token": "123456",
 		},
 		DisableMessageRetention: &[]bool{true}[0],

--- a/transactional.go
+++ b/transactional.go
@@ -29,7 +29,7 @@ var typeToApi = map[TransactionalType]string{
 
 var ErrInvalidTransactionalMessageType = errors.New("unknown transactional message type")
 
-func (c *APIClient) sendTransactional(ctx context.Context, typ TransactionalType, req interface{}) (*TransactionalResponse, error) {
+func (c *APIClient) sendTransactional(ctx context.Context, typ TransactionalType, req any) (*TransactionalResponse, error) {
 	api, ok := typeToApi[typ]
 	if !ok {
 		return nil, ErrInvalidTransactionalMessageType

--- a/transactional.go
+++ b/transactional.go
@@ -96,5 +96,5 @@ type TransactionalError struct {
 }
 
 func (e *TransactionalError) Error() string {
-	return e.Err
+	return fmt.Sprintf("%d: %s", e.StatusCode, e.Err)
 }

--- a/transactional_test.go
+++ b/transactional_test.go
@@ -21,14 +21,18 @@ func transactionalServer(t *testing.T, verify func(request []byte)) (*customerio
 		if err != nil {
 			t.Error(err)
 		}
-		defer req.Body.Close()
+		defer func() {
+			_ = req.Body.Close()
+		}()
 
 		verify(b)
 
-		w.Write([]byte(`{
-			"delivery_id": "` + testDeliveryID + `",
-			"queued_at": ` + strconv.Itoa(testQueuedAt) + `
-		  }`))
+		if _, err := w.Write([]byte(`{
+				"delivery_id": "` + testDeliveryID + `",
+				"queued_at": ` + strconv.Itoa(testQueuedAt) + `
+			  }`)); err != nil {
+			t.Error(err)
+		}
 	}))
 
 	api := customerio.NewAPIClient("myKey")

--- a/transactional_test.go
+++ b/transactional_test.go
@@ -1,7 +1,7 @@
 package customerio_test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -17,7 +17,7 @@ var (
 
 func transactionalServer(t *testing.T, verify func(request []byte)) (*customerio.APIClient, *httptest.Server) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		b, err := ioutil.ReadAll(req.Body)
+		b, err := io.ReadAll(req.Body)
 		if err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
General sweep on code style, CI and add a couple bits of best practice functionality

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core HTTP request construction/default client behavior (timeouts, transports, context propagation, response body limits) and makes API-facing type changes (`Option`, `Region`, `Device`, `map[string]any`) that could impact downstream compilation and runtime behavior.
> 
> **Overview**
> Modernizes the library’s client plumbing and public surface: clients now use a new default `*http.Client` with a **30s timeout**, a cloned default transport with `MaxIdleConnsPerHost=100`, request contexts are applied via `http.NewRequestWithContext`, and response bodies are read with a **1MiB limit**.
> 
> Refactors configuration to an exported `Option` interface, replaces mutable region structs with a typed `Region` enum (validated in `WithRegion`), hardens option handling (nil options ignored; panics on invalid region / nil HTTP client / empty user agent), and standardizes many payload types to `map[string]any` (raising `go.mod` to Go 1.21).
> 
> Fixes/adjusts API semantics: transactional push devices are now a public `Device` with `Token` (JSON `token`) and `SendPushRequest.Device` uses it; `CustomerIOError` gains accessors; `TransactionalError.Error()` includes status code; merge-customer validation errors become wrapped errors with clearer messages. CI is expanded with Dependabot, Go version matrix updates, pinned actions, plus `govulncheck` and `golangci-lint`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be5c0251e8d8abb733f5f205b5074f59604976b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->