### PR TITLE
MESS-689: Add support for add/remove customers from static segments in Track client

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,60 @@ if err != nil {
 fmt.Println(body)
 ```
 
+### Adding people to a manual segment
+
+Add customers to a manual segment by segment ID. Pass `customerio.WithSegmentIDType` to interpret the supplied ids as `email` or `cio_id` instead of the default `id`. [Learn more about adding customers to a segment](https://docs.customer.io/integrations/api/track/#tag/track-segments/add_to_segment).
+
+```go
+// Arguments
+// segmentID (required) - the integer ID of the manual segment.
+// ids (required)       - a []string of customer identifiers.
+// opts (optional)      - SegmentOption values, e.g. WithSegmentIDType to choose
+//                        between "id" (default), "email", or "cio_id".
+
+if err := track.AddPeopleToSegment(7, []string{"5", "6", "7"}); err != nil {
+  // handle error
+}
+```
+
+To interpret the supplied ids as email addresses or `cio_id`s, pass `WithSegmentIDType`:
+
+```go
+if err := track.AddPeopleToSegment(7,
+  []string{"alice@example.com", "bob@example.com"},
+  customerio.WithSegmentIDType(customerio.IdentifierTypeEmail),
+); err != nil {
+  // handle error
+}
+```
+
+### Removing people from a manual segment
+
+Remove customers from a manual segment by segment ID. Pass `customerio.WithSegmentIDType` to interpret the supplied ids as `email` or `cio_id` instead of the default `id`. [Learn more about removing customers from a segment](https://docs.customer.io/integrations/api/track/#tag/track-segments/remove_from_segment).
+
+```go
+// Arguments
+// segmentID (required) - the integer ID of the manual segment.
+// ids (required)       - a []string of customer identifiers to remove.
+// opts (optional)      - SegmentOption values, e.g. WithSegmentIDType to choose
+//                        between "id" (default), "email", or "cio_id".
+
+if err := track.RemovePeopleFromSegment(7, []string{"5", "6"}); err != nil {
+  // handle error
+}
+```
+
+To interpret the supplied ids as email addresses or `cio_id`s, pass `WithSegmentIDType`:
+
+```go
+if err := track.RemovePeopleFromSegment(7,
+  []string{"alice@example.com", "bob@example.com"},
+  customerio.WithSegmentIDType(customerio.IdentifierTypeEmail),
+); err != nil {
+  // handle error
+}
+```
+
 ## Context Support
 There are additional API methods that support passing a context that satisfies the `context.Context` interface to allow better control over dispatched requests. For example with sending an event:
 ```go

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ To interpret the supplied ids as email addresses or `cio_id`s, pass `WithSegment
 ```go
 if err := track.AddPeopleToSegment(7,
   []string{"alice@example.com", "bob@example.com"},
-  customerio.WithSegmentIDType(customerio.IdentifierTypeEmail),
+  customerio.WithSegmentIDType(customerio.IdentifierTypeEmail)
 ); err != nil {
   // handle error
 }
@@ -429,7 +429,7 @@ To interpret the supplied ids as email addresses or `cio_id`s, pass `WithSegment
 ```go
 if err := track.RemovePeopleFromSegment(7,
   []string{"alice@example.com", "bob@example.com"},
-  customerio.WithSegmentIDType(customerio.IdentifierTypeEmail),
+  customerio.WithSegmentIDType(customerio.IdentifierTypeEmail)
 ); err != nil {
   // handle error
 }

--- a/options.go
+++ b/options.go
@@ -1,6 +1,9 @@
 package customerio
 
-import "time"
+import (
+	"net/url"
+	"time"
+)
 
 type option struct {
 	api   func(*APIClient)
@@ -100,4 +103,15 @@ func trackPayload(eventName string, data map[string]interface{}, opts ...TrackOp
 	}
 
 	return payload
+}
+
+// SegmentOption configures optional query parameters on segment membership requests.
+type SegmentOption func(url.Values)
+
+// WithSegmentIDType sets the id_type query parameter, identifying which kind of
+// identifier the supplied ids represent. Defaults server-side to IdentifierTypeID.
+func WithSegmentIDType(t IdentifierType) SegmentOption {
+	return func(v url.Values) {
+		v.Set("id_type", string(t))
+	}
 }

--- a/segments.go
+++ b/segments.go
@@ -6,26 +6,16 @@ import (
 	"net/url"
 )
 
-// AddPeopleToSegmentCtx adds customers to a manual segment by segment ID.
+// AddPeopleToSegment adds customers to a manual segment by segment ID.
 // See https://docs.customer.io/api/track/#operation/add_customers
-func (c *CustomerIO) AddPeopleToSegmentCtx(ctx context.Context, segmentID int, ids []string, opts ...SegmentOption) error {
+func (c *CustomerIO) AddPeopleToSegment(ctx context.Context, segmentID int, ids []string, opts ...SegmentOption) error {
 	return c.segmentMembership(ctx, "add_customers", segmentID, ids, opts...)
 }
 
-// AddPeopleToSegment adds customers to a manual segment by segment ID.
-func (c *CustomerIO) AddPeopleToSegment(segmentID int, ids []string, opts ...SegmentOption) error {
-	return c.AddPeopleToSegmentCtx(context.Background(), segmentID, ids, opts...)
-}
-
-// RemovePeopleFromSegmentCtx removes customers from a manual segment by segment ID.
-// See https://docs.customer.io/api/track/#operation/remove_customers
-func (c *CustomerIO) RemovePeopleFromSegmentCtx(ctx context.Context, segmentID int, ids []string, opts ...SegmentOption) error {
-	return c.segmentMembership(ctx, "remove_customers", segmentID, ids, opts...)
-}
-
 // RemovePeopleFromSegment removes customers from a manual segment by segment ID.
-func (c *CustomerIO) RemovePeopleFromSegment(segmentID int, ids []string, opts ...SegmentOption) error {
-	return c.RemovePeopleFromSegmentCtx(context.Background(), segmentID, ids, opts...)
+// See https://docs.customer.io/api/track/#operation/remove_customers
+func (c *CustomerIO) RemovePeopleFromSegment(ctx context.Context, segmentID int, ids []string, opts ...SegmentOption) error {
+	return c.segmentMembership(ctx, "remove_customers", segmentID, ids, opts...)
 }
 
 func (c *CustomerIO) segmentMembership(ctx context.Context, action string, segmentID int, ids []string, opts ...SegmentOption) error {

--- a/segments.go
+++ b/segments.go
@@ -1,0 +1,54 @@
+package customerio
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// AddPeopleToSegmentCtx adds customers to a manual segment by segment ID.
+// See https://docs.customer.io/api/track/#operation/add_customers
+func (c *CustomerIO) AddPeopleToSegmentCtx(ctx context.Context, segmentID int, ids []string, opts ...SegmentOption) error {
+	return c.segmentMembership(ctx, "add_customers", segmentID, ids, opts...)
+}
+
+// AddPeopleToSegment adds customers to a manual segment by segment ID.
+func (c *CustomerIO) AddPeopleToSegment(segmentID int, ids []string, opts ...SegmentOption) error {
+	return c.AddPeopleToSegmentCtx(context.Background(), segmentID, ids, opts...)
+}
+
+// RemovePeopleFromSegmentCtx removes customers from a manual segment by segment ID.
+// See https://docs.customer.io/api/track/#operation/remove_customers
+func (c *CustomerIO) RemovePeopleFromSegmentCtx(ctx context.Context, segmentID int, ids []string, opts ...SegmentOption) error {
+	return c.segmentMembership(ctx, "remove_customers", segmentID, ids, opts...)
+}
+
+// RemovePeopleFromSegment removes customers from a manual segment by segment ID.
+func (c *CustomerIO) RemovePeopleFromSegment(segmentID int, ids []string, opts ...SegmentOption) error {
+	return c.RemovePeopleFromSegmentCtx(context.Background(), segmentID, ids, opts...)
+}
+
+func (c *CustomerIO) segmentMembership(ctx context.Context, action string, segmentID int, ids []string, opts ...SegmentOption) error {
+	if segmentID <= 0 {
+		return ParamError{Param: "segmentID"}
+	}
+	if len(ids) == 0 {
+		return ParamError{Param: "ids"}
+	}
+
+	u := fmt.Sprintf("%s/api/v1/segments/%d/%s", c.URL, segmentID, action)
+
+	// url.Values handles encoding for any future option that carries an
+	// arbitrary string; current options (id_type) only emit URL-safe values.
+	q := url.Values{}
+	for _, opt := range opts {
+		opt(q)
+	}
+	if encoded := q.Encode(); encoded != "" {
+		u += "?" + encoded
+	}
+
+	return c.request(ctx, "POST", u, map[string]interface{}{
+		"ids": ids,
+	})
+}

--- a/segments_test.go
+++ b/segments_test.go
@@ -1,6 +1,7 @@
 package customerio_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/customerio/go-customerio/v3"
@@ -13,10 +14,12 @@ var (
 )
 
 func TestAddPeopleToSegment(t *testing.T) {
-	checkParamError(t, cio.AddPeopleToSegment(0, idsByID), "segmentID")
-	checkParamError(t, cio.AddPeopleToSegment(-1, idsByID), "segmentID")
-	checkParamError(t, cio.AddPeopleToSegment(7, nil), "ids")
-	checkParamError(t, cio.AddPeopleToSegment(7, []string{}), "ids")
+	ctx := context.Background()
+
+	checkParamError(t, cio.AddPeopleToSegment(ctx, 0, idsByID), "segmentID")
+	checkParamError(t, cio.AddPeopleToSegment(ctx, -1, idsByID), "segmentID")
+	checkParamError(t, cio.AddPeopleToSegment(ctx, 7, nil), "ids")
+	checkParamError(t, cio.AddPeopleToSegment(ctx, 7, []string{}), "ids")
 
 	runCases(t,
 		[]testCase{
@@ -27,20 +30,22 @@ func TestAddPeopleToSegment(t *testing.T) {
 		func(c testCase) error {
 			switch c.id {
 			case "email":
-				return cio.AddPeopleToSegment(7, idsByEmail, customerio.WithSegmentIDType(customerio.IdentifierTypeEmail))
+				return cio.AddPeopleToSegment(ctx, 7, idsByEmail, customerio.WithSegmentIDType(customerio.IdentifierTypeEmail))
 			case "cio_id":
-				return cio.AddPeopleToSegment(7, idsByCioID, customerio.WithSegmentIDType(customerio.IdentifierTypeCioID))
+				return cio.AddPeopleToSegment(ctx, 7, idsByCioID, customerio.WithSegmentIDType(customerio.IdentifierTypeCioID))
 			default:
-				return cio.AddPeopleToSegment(7, idsByID)
+				return cio.AddPeopleToSegment(ctx, 7, idsByID)
 			}
 		})
 }
 
 func TestRemovePeopleFromSegment(t *testing.T) {
-	checkParamError(t, cio.RemovePeopleFromSegment(0, idsByID), "segmentID")
-	checkParamError(t, cio.RemovePeopleFromSegment(-1, idsByID), "segmentID")
-	checkParamError(t, cio.RemovePeopleFromSegment(7, nil), "ids")
-	checkParamError(t, cio.RemovePeopleFromSegment(7, []string{}), "ids")
+	ctx := context.Background()
+
+	checkParamError(t, cio.RemovePeopleFromSegment(ctx, 0, idsByID), "segmentID")
+	checkParamError(t, cio.RemovePeopleFromSegment(ctx, -1, idsByID), "segmentID")
+	checkParamError(t, cio.RemovePeopleFromSegment(ctx, 7, nil), "ids")
+	checkParamError(t, cio.RemovePeopleFromSegment(ctx, 7, []string{}), "ids")
 
 	runCases(t,
 		[]testCase{
@@ -51,11 +56,11 @@ func TestRemovePeopleFromSegment(t *testing.T) {
 		func(c testCase) error {
 			switch c.id {
 			case "email":
-				return cio.RemovePeopleFromSegment(7, idsByEmail, customerio.WithSegmentIDType(customerio.IdentifierTypeEmail))
+				return cio.RemovePeopleFromSegment(ctx, 7, idsByEmail, customerio.WithSegmentIDType(customerio.IdentifierTypeEmail))
 			case "cio_id":
-				return cio.RemovePeopleFromSegment(7, idsByCioID, customerio.WithSegmentIDType(customerio.IdentifierTypeCioID))
+				return cio.RemovePeopleFromSegment(ctx, 7, idsByCioID, customerio.WithSegmentIDType(customerio.IdentifierTypeCioID))
 			default:
-				return cio.RemovePeopleFromSegment(7, idsByID)
+				return cio.RemovePeopleFromSegment(ctx, 7, idsByID)
 			}
 		})
 }

--- a/segments_test.go
+++ b/segments_test.go
@@ -1,0 +1,61 @@
+package customerio_test
+
+import (
+	"testing"
+
+	"github.com/customerio/go-customerio/v3"
+)
+
+var (
+	idsByID    = []string{"1", "2", "3"}
+	idsByEmail = []string{"alice@example.com", "bob@example.com"}
+	idsByCioID = []string{"cio_abc123", "cio_def456"}
+)
+
+func TestAddPeopleToSegment(t *testing.T) {
+	checkParamError(t, cio.AddPeopleToSegment(0, idsByID), "segmentID")
+	checkParamError(t, cio.AddPeopleToSegment(-1, idsByID), "segmentID")
+	checkParamError(t, cio.AddPeopleToSegment(7, nil), "ids")
+	checkParamError(t, cio.AddPeopleToSegment(7, []string{}), "ids")
+
+	runCases(t,
+		[]testCase{
+			{"default", "POST", "/api/v1/segments/7/add_customers", map[string]interface{}{"ids": idsByID}},
+			{"email", "POST", "/api/v1/segments/7/add_customers?id_type=email", map[string]interface{}{"ids": idsByEmail}},
+			{"cio_id", "POST", "/api/v1/segments/7/add_customers?id_type=cio_id", map[string]interface{}{"ids": idsByCioID}},
+		},
+		func(c testCase) error {
+			switch c.id {
+			case "email":
+				return cio.AddPeopleToSegment(7, idsByEmail, customerio.WithSegmentIDType(customerio.IdentifierTypeEmail))
+			case "cio_id":
+				return cio.AddPeopleToSegment(7, idsByCioID, customerio.WithSegmentIDType(customerio.IdentifierTypeCioID))
+			default:
+				return cio.AddPeopleToSegment(7, idsByID)
+			}
+		})
+}
+
+func TestRemovePeopleFromSegment(t *testing.T) {
+	checkParamError(t, cio.RemovePeopleFromSegment(0, idsByID), "segmentID")
+	checkParamError(t, cio.RemovePeopleFromSegment(-1, idsByID), "segmentID")
+	checkParamError(t, cio.RemovePeopleFromSegment(7, nil), "ids")
+	checkParamError(t, cio.RemovePeopleFromSegment(7, []string{}), "ids")
+
+	runCases(t,
+		[]testCase{
+			{"default", "POST", "/api/v1/segments/7/remove_customers", map[string]interface{}{"ids": idsByID}},
+			{"email", "POST", "/api/v1/segments/7/remove_customers?id_type=email", map[string]interface{}{"ids": idsByEmail}},
+			{"cio_id", "POST", "/api/v1/segments/7/remove_customers?id_type=cio_id", map[string]interface{}{"ids": idsByCioID}},
+		},
+		func(c testCase) error {
+			switch c.id {
+			case "email":
+				return cio.RemovePeopleFromSegment(7, idsByEmail, customerio.WithSegmentIDType(customerio.IdentifierTypeEmail))
+			case "cio_id":
+				return cio.RemovePeopleFromSegment(7, idsByCioID, customerio.WithSegmentIDType(customerio.IdentifierTypeCioID))
+			default:
+				return cio.RemovePeopleFromSegment(7, idsByID)
+			}
+		})
+}


### PR DESCRIPTION
Adds support for endpoints:

- POST /api/v1/segments/{segment_id}/add_customers
- POST /api/v1/segments/{segment_id}/remove_customers

## For the curious:
- Adds `AddPeopleToSegment` / `RemovePeopleFromSegment` (plus `Ctx` variants) on the Track client
- Introduces a new `SegmentOption` functional-option family with `WithSegmentIDType` to select between `id` (default), `email`, and `cio_id` via the `id_type` query parameter.
- Updates README with usage examples for both methods, linking to online docs


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Track client methods for segment membership with basic parameter validation and unit tests, without changing existing request flows.
> 
> **Overview**
> Adds Track client support for managing manual segment membership via new `AddPeopleToSegment` and `RemovePeopleFromSegment` methods that POST ids to the `/api/v1/segments/{id}/add_customers` and `/remove_customers` endpoints.
> 
> Introduces `SegmentOption` (currently `WithSegmentIDType`) to set the `id_type` query parameter (e.g. `email`, `cio_id`) and updates the README with usage examples and links to the corresponding API docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4252dd82865ceaef45803053c714be002ecbce64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->