### PR TITLE
Fix untyped TransactionalType constants

### DIFF
--- a/transactional.go
+++ b/transactional.go
@@ -12,11 +12,11 @@ import (
 type TransactionalType int
 
 const (
-	TransactionalTypeEmail        = 0
-	TransactionalTypePush         = 1
-	TransactionalTypeSMS          = 2
-	TransactionalTypeInboxMessage = 3
-	TransactionalTypeInApp        = 4
+	TransactionalTypeEmail        TransactionalType = iota
+	TransactionalTypePush
+	TransactionalTypeSMS
+	TransactionalTypeInboxMessage
+	TransactionalTypeInApp
 )
 
 var typeToApi = map[TransactionalType]string{

--- a/transactional.go
+++ b/transactional.go
@@ -12,11 +12,11 @@ import (
 type TransactionalType int
 
 const (
-	TransactionalTypeEmail        TransactionalType = 1
-	TransactionalTypePush         TransactionalType = 2
-	TransactionalTypeSMS          TransactionalType = 3
-	TransactionalTypeInboxMessage TransactionalType = 4
-	TransactionalTypeInApp        TransactionalType = 5
+	TransactionalTypeEmail        TransactionalType = 0
+	TransactionalTypePush         TransactionalType = 1
+	TransactionalTypeSMS          TransactionalType = 2
+	TransactionalTypeInboxMessage TransactionalType = 3
+	TransactionalTypeInApp        TransactionalType = 4
 )
 
 var typeToApi = map[TransactionalType]string{

--- a/transactional.go
+++ b/transactional.go
@@ -12,11 +12,11 @@ import (
 type TransactionalType int
 
 const (
-	TransactionalTypeEmail TransactionalType = iota
-	TransactionalTypePush
-	TransactionalTypeSMS
-	TransactionalTypeInboxMessage
-	TransactionalTypeInApp
+	TransactionalTypeEmail        TransactionalType = 1
+	TransactionalTypePush         TransactionalType = 2
+	TransactionalTypeSMS          TransactionalType = 3
+	TransactionalTypeInboxMessage TransactionalType = 4
+	TransactionalTypeInApp        TransactionalType = 5
 )
 
 var typeToApi = map[TransactionalType]string{

--- a/transactional.go
+++ b/transactional.go
@@ -12,7 +12,7 @@ import (
 type TransactionalType int
 
 const (
-	TransactionalTypeEmail        TransactionalType = iota
+	TransactionalTypeEmail TransactionalType = iota
 	TransactionalTypePush
 	TransactionalTypeSMS
 	TransactionalTypeInboxMessage


### PR DESCRIPTION
## Summary
- The `TransactionalType` constants (`TransactionalTypeEmail`, `TransactionalTypePush`, etc.) were declared as untyped integers, allowing any bare `int` to satisfy the `typeToApi` map lookup without explicit conversion.
- Changed to use `iota` with an explicit `TransactionalType` type annotation so the compiler enforces type safety at call sites.

## Test plan
- [x] `go test -race ./...` passes with no failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small API typing change in transactional message constants with no runtime behavior change.
> 
> **Overview**
> **TransactionalType** constants are now explicitly typed as `TransactionalType` instead of untyped integer literals.
> 
> This tightens compile-time safety for `typeToApi` lookups and `sendTransactional`, so bare `int` values can no longer be passed where a `TransactionalType` is required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e79e2757f2fc4cabca324448852a2272bb15edf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->