### PR TITLE
Add error-path tests for push, SMS, in-app, and inbox sends

### DIFF
--- a/send_email_test.go
+++ b/send_email_test.go
@@ -84,7 +84,7 @@ func TestSendEmailError(t *testing.T) {
 		t.Errorf("Expected error, got: %#v", resp)
 	}
 
-	if e, ok := err.(*customerio.TransactionalError); !ok {
-		t.Errorf("Expected TransactionalError, got: %#v", e)
+	if _, ok := err.(*customerio.TransactionalError); !ok {
+		t.Errorf("Expected TransactionalError, got: %#v", err)
 	}
 }

--- a/send_in_app_test.go
+++ b/send_in_app_test.go
@@ -3,6 +3,8 @@ package customerio_test
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 	"time"
@@ -49,5 +51,29 @@ func TestSendInApp(t *testing.T) {
 
 	if !reflect.DeepEqual(resp, expect) {
 		t.Errorf("Expect: %#v, Got: %#v", expect, resp)
+	}
+}
+
+func TestSendInAppError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(502)
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	resp, err := api.SendInApp(context.Background(), &customerio.SendInAppRequest{
+		TransactionalMessageID: "123456",
+		Identifiers: map[string]string{
+			"id": "customer_1",
+		},
+	})
+	if err == nil {
+		t.Errorf("Expected error, got: %#v", resp)
+	}
+
+	if e, ok := err.(*customerio.TransactionalError); !ok {
+		t.Errorf("Expected TransactionalError, got: %#v", e)
 	}
 }

--- a/send_in_app_test.go
+++ b/send_in_app_test.go
@@ -73,7 +73,7 @@ func TestSendInAppError(t *testing.T) {
 		t.Errorf("Expected error, got: %#v", resp)
 	}
 
-	if e, ok := err.(*customerio.TransactionalError); !ok {
-		t.Errorf("Expected TransactionalError, got: %#v", e)
+	if _, ok := err.(*customerio.TransactionalError); !ok {
+		t.Errorf("Expected TransactionalError, got: %#v", err)
 	}
 }

--- a/send_inbox_message_test.go
+++ b/send_inbox_message_test.go
@@ -73,7 +73,7 @@ func TestSendInboxMessageError(t *testing.T) {
 		t.Errorf("Expected error, got: %#v", resp)
 	}
 
-	if e, ok := err.(*customerio.TransactionalError); !ok {
-		t.Errorf("Expected TransactionalError, got: %#v", e)
+	if _, ok := err.(*customerio.TransactionalError); !ok {
+		t.Errorf("Expected TransactionalError, got: %#v", err)
 	}
 }

--- a/send_inbox_message_test.go
+++ b/send_inbox_message_test.go
@@ -3,6 +3,8 @@ package customerio_test
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 	"time"
@@ -49,5 +51,29 @@ func TestSendInboxMessage(t *testing.T) {
 
 	if !reflect.DeepEqual(resp, expect) {
 		t.Errorf("Expect: %#v, Got: %#v", expect, resp)
+	}
+}
+
+func TestSendInboxMessageError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(502)
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	resp, err := api.SendInboxMessage(context.Background(), &customerio.SendInboxMessageRequest{
+		TransactionalMessageID: "123456",
+		Identifiers: map[string]string{
+			"id": "customer_1",
+		},
+	})
+	if err == nil {
+		t.Errorf("Expected error, got: %#v", resp)
+	}
+
+	if e, ok := err.(*customerio.TransactionalError); !ok {
+		t.Errorf("Expected TransactionalError, got: %#v", e)
 	}
 }

--- a/send_push_test.go
+++ b/send_push_test.go
@@ -3,6 +3,8 @@ package customerio_test
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 	"time"
@@ -57,5 +59,31 @@ func TestSendPush(t *testing.T) {
 
 	if !reflect.DeepEqual(resp, expect) {
 		t.Errorf("Expect: %#v, Got: %#v", expect, resp)
+	}
+}
+
+func TestSendPushError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(502)
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	resp, err := api.SendPush(context.Background(), &customerio.SendPushRequest{
+		Identifiers: map[string]string{
+			"id": "customer_1",
+		},
+		To:      "customer@example.com",
+		Title:   "hello",
+		Message: "hello from Go",
+	})
+	if err == nil {
+		t.Errorf("Expected error, got: %#v", resp)
+	}
+
+	if e, ok := err.(*customerio.TransactionalError); !ok {
+		t.Errorf("Expected TransactionalError, got: %#v", e)
 	}
 }

--- a/send_push_test.go
+++ b/send_push_test.go
@@ -83,7 +83,7 @@ func TestSendPushError(t *testing.T) {
 		t.Errorf("Expected error, got: %#v", resp)
 	}
 
-	if e, ok := err.(*customerio.TransactionalError); !ok {
-		t.Errorf("Expected TransactionalError, got: %#v", e)
+	if _, ok := err.(*customerio.TransactionalError); !ok {
+		t.Errorf("Expected TransactionalError, got: %#v", err)
 	}
 }

--- a/send_sms_test.go
+++ b/send_sms_test.go
@@ -3,6 +3,8 @@ package customerio_test
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 	"time"
@@ -52,5 +54,30 @@ func TestSendSMS(t *testing.T) {
 
 	if !reflect.DeepEqual(resp, expect) {
 		t.Errorf("Expect: %#v, Got: %#v", expect, resp)
+	}
+}
+
+func TestSendSMSError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(502)
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	resp, err := api.SendSMS(context.Background(), &customerio.SendSMSRequest{
+		TransactionalMessageID: "123456",
+		Identifiers: map[string]string{
+			"id": "customer_1",
+		},
+		To: "+12345678900",
+	})
+	if err == nil {
+		t.Errorf("Expected error, got: %#v", resp)
+	}
+
+	if e, ok := err.(*customerio.TransactionalError); !ok {
+		t.Errorf("Expected TransactionalError, got: %#v", e)
 	}
 }

--- a/send_sms_test.go
+++ b/send_sms_test.go
@@ -77,7 +77,7 @@ func TestSendSMSError(t *testing.T) {
 		t.Errorf("Expected error, got: %#v", resp)
 	}
 
-	if e, ok := err.(*customerio.TransactionalError); !ok {
-		t.Errorf("Expected TransactionalError, got: %#v", e)
+	if _, ok := err.(*customerio.TransactionalError); !ok {
+		t.Errorf("Expected TransactionalError, got: %#v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Only `SendEmail` had an error-path test (`TestSendEmailError`)
- Adds `TestSendPushError`, `TestSendSMSError`, `TestSendInAppError`, and `TestSendInboxMessageError`
- Each test: server returns 502, asserts `TransactionalError` is returned

## Test plan
- [x] `go test -race ./...` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code paths modified.
> 
> **Overview**
> Extends **transactional send error-path test coverage** so push, SMS, in-app, and inbox match the existing email pattern.
> 
> Adds **`TestSendPushError`**, **`TestSendSMSError`**, **`TestSendInAppError`**, and **`TestSendInboxMessageError`**. Each spins up an **`httptest`** server that returns **502**, points the API client at it, calls the corresponding send method, and asserts the error is a **`*customerio.TransactionalError`**.
> 
> **`TestSendEmailError`** is tightened only in the assertion: the type check no longer binds the wrong variable, and failure messages report **`err`** instead of the assertion value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a437df421ddaea1fe6c53bbe154fa34d0335bccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->