### PR TITLE
Bump minimum Go version from 1.21 to 1.22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.21.x", "1.22.x", "1.23.x", "1.24.x", "1.25.x", "stable"]
+        go: ["1.22.x", "1.23.x", "1.24.x", "1.25.x", "stable"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/customerio/go-customerio/v3
 
-go 1.21
+go 1.22


### PR DESCRIPTION
## Summary
- Go 1.21 has been EOL since Aug 2024
- Bumps `go.mod` from `go 1.21` to `go 1.22`
- Drops `1.21.x` from CI matrix

## Test plan
- [x] `go test -race ./...` passes
- [x] `go mod tidy` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only raises the minimum supported Go version and updates CI accordingly, with no functional code changes.
> 
> **Overview**
> **Raises the minimum supported Go version to 1.22** by updating `go.mod` from `go 1.21` to `go 1.22`.
> 
> CI is aligned by removing Go `1.21.x` from the GitHub Actions test matrix, so tests now run on `1.22.x` and newer (plus `stable`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef1d6ebba06b34a3a42b0343abfb96135bdf5d8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->