### PR TITLE
Extract shared HTTP logic into doHTTP

### DIFF
--- a/api.go
+++ b/api.go
@@ -1,10 +1,7 @@
 package customerio
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"io"
 	"net/http"
 )
 
@@ -37,36 +34,8 @@ func NewAPIClient(key string, opts ...Option) *APIClient {
 	return client
 }
 
-// doRequest returns the raw response body and status code. Callers
-// must check the status code and handle errors; unlike CustomerIO.request(),
-// this method does not return an error for non-200 responses.
 func (c *APIClient) doRequest(ctx context.Context, verb, requestPath string, body any) ([]byte, int, error) {
-	b, err := json.Marshal(body)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	req, err := http.NewRequestWithContext(ctx, verb, c.URL+requestPath, bytes.NewBuffer(b))
-	if err != nil {
-		return nil, 0, err
-	}
-
-	req.Header.Set("Authorization", "Bearer "+c.Key)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Add("User-Agent", c.UserAgent)
-
-	resp, err := c.Client.Do(req)
-	if err != nil {
-		return nil, 0, err
-	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
-
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	if err != nil {
-		return nil, 0, err
-	}
-
-	return respBody, resp.StatusCode, nil
+	return doHTTP(ctx, c.Client, verb, c.URL+requestPath, c.UserAgent, body, func(req *http.Request) {
+		req.Header.Set("Authorization", "Bearer "+c.Key)
+	})
 }

--- a/customerio.go
+++ b/customerio.go
@@ -1,13 +1,10 @@
 package customerio
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -155,48 +152,18 @@ func (c *CustomerIO) auth() string {
 }
 
 func (c *CustomerIO) request(ctx context.Context, method, url string, body any) error {
-	var req *http.Request
-	if body != nil {
-		j, err := json.Marshal(body)
-		if err != nil {
-			return err
-		}
-
-		req, err = http.NewRequestWithContext(ctx, method, url, bytes.NewBuffer(j))
-		if err != nil {
-			return err
-		}
-
-		req.Header.Add("User-Agent", c.UserAgent)
-		req.Header.Add("Content-Type", "application/json")
-	} else {
-		var err error
-		req, err = http.NewRequestWithContext(ctx, method, url, nil)
-		if err != nil {
-			return err
-		}
-	}
-
-	req.Header.Add("Authorization", fmt.Sprintf("Basic %v", c.auth()))
-
-	resp, err := c.Client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
-
-	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	respBody, statusCode, err := doHTTP(ctx, c.Client, method, url, c.UserAgent, body, func(req *http.Request) {
+		req.Header.Set("Authorization", fmt.Sprintf("Basic %v", c.auth()))
+	})
 	if err != nil {
 		return err
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if statusCode != http.StatusOK {
 		return &CustomerIOError{
-			status: resp.StatusCode,
+			status: statusCode,
 			url:    url,
-			body:   responseBody,
+			body:   respBody,
 		}
 	}
 

--- a/http.go
+++ b/http.go
@@ -23,7 +23,7 @@ func newDefaultHTTPClient() *http.Client {
 
 // doHTTP is the shared HTTP execution path for both CustomerIO (Track) and
 // APIClient (App API). Auth header injection is caller-supplied via setAuth.
-func doHTTP(ctx context.Context, client HTTPClient, method, url, userAgent string, body any, setAuth func(*http.Request)) ([]byte, int, error) {
+func doHTTP(ctx context.Context, client HTTPClient, method, url, userAgent string, body any, preflight func(*http.Request)) ([]byte, int, error) {
 	var req *http.Request
 	if body != nil {
 		b, err := json.Marshal(body)
@@ -44,7 +44,7 @@ func doHTTP(ctx context.Context, client HTTPClient, method, url, userAgent strin
 	}
 
 	req.Header.Set("User-Agent", userAgent)
-	setAuth(req)
+	preflight(req)
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/http.go
+++ b/http.go
@@ -1,6 +1,10 @@
 package customerio
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"time"
 )
@@ -15,6 +19,47 @@ func newDefaultHTTPClient() *http.Client {
 		Timeout:   DefaultHTTPTimeout,
 		Transport: newDefaultTransport(),
 	}
+}
+
+// doHTTP is the shared HTTP execution path for both CustomerIO (Track) and
+// APIClient (App API). Auth header injection is caller-supplied via setAuth.
+func doHTTP(ctx context.Context, client HTTPClient, method, url, userAgent string, body any, setAuth func(*http.Request)) ([]byte, int, error) {
+	var req *http.Request
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return nil, 0, err
+		}
+		req, err = http.NewRequestWithContext(ctx, method, url, bytes.NewBuffer(b))
+		if err != nil {
+			return nil, 0, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		var err error
+		req, err = http.NewRequestWithContext(ctx, method, url, nil)
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+
+	req.Header.Set("User-Agent", userAgent)
+	setAuth(req)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return respBody, resp.StatusCode, nil
 }
 
 func newDefaultTransport() http.RoundTripper {


### PR DESCRIPTION
## Summary
- `CustomerIO.request()` and `APIClient.doRequest()` duplicated the same marshal → create request → set headers → execute → read body pipeline
- Extracts `doHTTP()` in `http.go` that accepts an auth callback; both clients delegate to it
- Auth (Basic vs Bearer) and error handling remain caller-specific
- Also fixes minor bug: `CustomerIO.request()` was not setting User-Agent header on DELETE requests (nil body path)
- Net -19 lines

## Test plan
- [x] `go test -race ./...` passes
- [x] No public API changes — internal refactor only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with no public API changes; behavior is intended to stay the same aside from the User-Agent fix on nil-body Track requests.
> 
> **Overview**
> Consolidates duplicated HTTP request logic from `CustomerIO.request()` and `APIClient.doRequest()` into a new shared **`doHTTP`** helper in `http.go`. Both clients now delegate marshaling, request construction, **`User-Agent`**, auth via a caller **`preflight`** hook (Basic vs Bearer), execution, and body reads to that path while keeping their own status/error handling.
> 
> Also fixes **`CustomerIO`** requests with a nil body (e.g. **DELETE**) so **`User-Agent`** is set consistently, which the old nil-body branch skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce5caebda772346cca25d3ff5e4fbbe425f3ed1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->