### PR TITLE
Deprecate directly-exported fields on APIClient

### DIFF
--- a/api.go
+++ b/api.go
@@ -13,10 +13,14 @@ type HTTPClient interface {
 }
 
 type APIClient struct {
-	Key       string
-	URL       string
+	// Deprecated: Use NewAPIClient constructor options instead. Will be unexported in v4.
+	Key string
+	// Deprecated: Use NewAPIClient with WithURL or WithRegion instead. Will be unexported in v4.
+	URL string
+	// Deprecated: Use NewAPIClient with WithUserAgent instead. Will be unexported in v4.
 	UserAgent string
-	Client    HTTPClient
+	// Deprecated: Use NewAPIClient with WithHTTPClient instead. Will be unexported in v4.
+	Client HTTPClient
 }
 
 // NewAPIClient prepares a client for use with the Customer.io API, see: https://customer.io/docs/api/#apicoreintroduction

--- a/options.go
+++ b/options.go
@@ -83,6 +83,22 @@ func WithHTTPClient(client HTTPClient) Option {
 	}
 }
 
+// WithURL overrides the base URL for API requests. Most callers should use
+// WithRegion instead; this is intended for tests or on-premise deployments.
+func WithURL(url string) Option {
+	if url == "" {
+		panic("customerio: WithURL called with empty string")
+	}
+	return option{
+		api: func(a *APIClient) {
+			a.URL = url
+		},
+		track: func(c *CustomerIO) {
+			c.URL = url
+		},
+	}
+}
+
 func WithUserAgent(ua string) Option {
 	if ua == "" {
 		panic("customerio: WithUserAgent called with empty string")


### PR DESCRIPTION
## Summary
- Marks `Key`, `URL`, `UserAgent`, and `Client` fields on `APIClient` as deprecated via godoc comments
- Each comment points to the appropriate constructor option (`WithURL`, `WithHTTPClient`, etc.)
- Adds new `WithURL` option that applies to both `APIClient` and `CustomerIO` (for tests / on-premise)
- No breaking changes — fields remain exported, full removal deferred to v4

## Test plan
- [x] `go test -race ./...` passes
- [x] Existing tests that set `api.URL = srv.URL` directly still work

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to doc deprecations and a new optional constructor option; runtime behavior is unchanged unless callers opt into `WithURL`, which only affects request base URLs.
> 
> **Overview**
> Marks `APIClient` fields (`Key`, `URL`, `UserAgent`, `Client`) as *deprecated* in godoc, steering callers toward `NewAPIClient` options ahead of a planned v4 unexport.
> 
> Adds `WithURL` to override the base URL (intended for tests/on-prem), applying the override to both `APIClient` and `CustomerIO`, with a panic on empty input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8584187003e997c868debbd9aeb1b20e04e31f36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->