### PR TITLE
refactor(customerio): build URLs with net/url instead of fmt.Sprintf [AMPB-826]

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,11 @@ if err := track.TrackCtx(ctx, "5", "purchase", map[string]interface{}{
 }
 ```
 
+## Segments API
+
+We also provide a client for managing customer segments through the Segments API. For more details on how to use it, refer to the [Segments API README](./SEGMENTS.md).
+
+
 ## Contributing
 
 1. Fork it

--- a/SEGMENTS.md
+++ b/SEGMENTS.md
@@ -1,0 +1,176 @@
+# Customer.io Segments API Methods
+
+This document explains how to use the new methods added for managing customer segments in Customer.io. These methods enable you to list, create, delete segments, and manage customers in segments.
+
+## Usage
+
+### Available Methods
+
+1. **Create Segment**
+
+   Creates a new segment in Customer.io.
+
+    ```go
+    request := &CreateSegmentRequest{
+		Segment: Segment{
+			Name: "New Segment",
+		},
+	}
+
+	resp, err := cio.CreateSegment(context.Background(), request)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("Segment created: ID: %d, Name: %s", resp.Segment.ID, resp.Segment.Name)
+    ```
+
+2. **List Segments**
+
+   Retrieves a list of all customer segments.
+
+    ```go
+    segments, err := cio.ListSegments(context.Background())
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    for _, segment := range segments.Segments {
+        log.Printf("Segment ID: %d, Name: %s", segment.ID, segment.Name)
+    }
+    ```
+
+3. **Get Segment by ID**
+
+   Retrieves a specific segment by its ID.
+
+    ```go
+    segmentID := 1234
+	resp, err := cio.GetSegment(context.Background(), segmentID)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("Segment ID: %d, Name: %s", resp.Segment.ID, resp.Segment.Name)
+    ```
+
+4. **Delete Segment**
+
+   Deletes a segment by its ID.
+
+    ```go
+    segmentID := 1234
+    err := cio.DeleteSegment(context.Background(), segmentID)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Println("Segment deleted successfully")
+    ```
+
+5. **Get Segment Dependencies**
+
+   Retrieves dependencies for a specific segment.
+
+    ```go
+    segmentID := 1234
+    dependencies, err := cio.GetSegmentDependencies(context.Background(), segmentID)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Segment dependencies: %v", dependencies)
+    ```
+
+6. **Get Segment Customer Count**
+
+   Retrieves the number of customers in a specific segment.
+
+    ```go
+    segmentID := 1234
+    count, err := cio.GetSegmentCustomerCount(context.Background(), segmentID)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Customer count in segment %d: %d", segmentID, count.Count)
+    ```
+
+7. **List Customers in a Segment**
+
+   Retrieves a list of customers in a specific segment.
+
+    ```go
+    segmentID := 1234
+	customers, err := cio.ListCustomersInSegment(context.Background(), segmentID)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, customer := range customers.Identifiers {
+		log.Printf("Customer ID: %d", customer.ID)
+	}
+    ```
+
+### Managing Customers in Segments
+
+You can add or remove customers from segments using the following methods:
+
+1. **Add People to Segment**
+
+   Adds a list of customer IDs to a segment.
+
+    ```go
+    segmentID := 1234
+	customerIDs := []string{"customer_1", "customer_2"}
+
+	err := track.AddPeopleToSegment(context.Background(), segmentID, customerIDs)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Println("Customers added to segment successfully")
+    ```
+
+2. **Remove People from Segment**
+
+   Removes a list of customer IDs from a segment.
+
+    ```go
+    segmentID := 1234
+	customerIDs := []string{"customer_1", "customer_2"}
+
+	err := track.RemovePeopleFromSegment(context.Background(), segmentID, customerIDs)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Println("Customers removed from segment successfully")
+    ```
+
+## Example: Creating a Segment and Adding Customers
+
+```go
+func main() {
+    // Create a new segment
+	request := &CreateSegmentRequest{
+		Segment: Segment{
+			Name: "VIP Customers",
+		},
+	}
+	resp, err := cio.CreateSegment(context.Background(), request)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("Created segment: %s (ID: %d)", resp.Segment.Name, resp.Segment.ID)
+
+	// Add customers to the new segment
+	customerIDs := []string{"customer_1", "customer_2"}
+	err = track.AddPeopleToSegment(context.Background(), resp.Segment.ID, customerIDs)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Println("Customers added to the segment successfully")
+}

--- a/api.go
+++ b/api.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"io/ioutil"
 	"net/http"
 )
@@ -32,12 +33,17 @@ func NewAPIClient(key string, opts ...option) *APIClient {
 }
 
 func (c *APIClient) doRequest(ctx context.Context, verb, requestPath string, body interface{}) ([]byte, int, error) {
-	b, err := json.Marshal(body)
-	if err != nil {
-		return nil, 0, err
+	var requestBody io.Reader
+
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return nil, 0, err
+		}
+		requestBody = bytes.NewBuffer(b)
 	}
 
-	req, err := http.NewRequest(verb, c.URL+requestPath, bytes.NewBuffer(b))
+	req, err := http.NewRequest(verb, c.URL+requestPath, requestBody)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/api.go
+++ b/api.go
@@ -32,7 +32,7 @@ func NewAPIClient(key string, opts ...option) *APIClient {
 	return client
 }
 
-func (c *APIClient) doRequest(ctx context.Context, verb, requestPath string, body interface{}) ([]byte, int, error) {
+func (c *APIClient) doRequest(ctx context.Context, verb string, body interface{}, segments ...string) ([]byte, int, error) {
 	var requestBody io.Reader
 
 	if body != nil {
@@ -43,7 +43,12 @@ func (c *APIClient) doRequest(ctx context.Context, verb, requestPath string, bod
 		requestBody = bytes.NewBuffer(b)
 	}
 
-	req, err := http.NewRequest(verb, c.URL+requestPath, requestBody)
+	u, err := buildURL(c.URL, nil, segments...)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	req, err := http.NewRequest(verb, u, requestBody)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/customerio.go
+++ b/customerio.go
@@ -22,6 +22,7 @@ type CustomerIO struct {
 	apiKey    string
 	URL       string
 	UserAgent string
+	IDType    string
 	Client    *http.Client
 }
 

--- a/customerio.go
+++ b/customerio.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 )
@@ -78,9 +77,11 @@ func (c *CustomerIO) IdentifyCtx(ctx context.Context, customerID string, attribu
 	if customerID == "" {
 		return ParamError{Param: "customerID"}
 	}
-	return c.request(ctx, "PUT",
-		fmt.Sprintf("%s/api/v1/customers/%s", c.URL, url.PathEscape(customerID)),
-		attributes)
+	u, err := buildURL(c.URL, nil, "api", "v1", "customers", customerID)
+	if err != nil {
+		return err
+	}
+	return c.request(ctx, "PUT", u, attributes)
 }
 
 // Identify identifies a customer and sets their attributes
@@ -96,12 +97,14 @@ func (c *CustomerIO) TrackCtx(ctx context.Context, customerID string, eventName 
 	if eventName == "" {
 		return ParamError{Param: "eventName"}
 	}
-	return c.request(ctx, "POST",
-		fmt.Sprintf("%s/api/v1/customers/%s/events", c.URL, url.PathEscape(customerID)),
-		map[string]interface{}{
-			"name": eventName,
-			"data": data,
-		})
+	u, err := buildURL(c.URL, nil, "api", "v1", "customers", customerID, "events")
+	if err != nil {
+		return err
+	}
+	return c.request(ctx, "POST", u, map[string]interface{}{
+		"name": eventName,
+		"data": data,
+	})
 }
 
 // Track sends a single event to Customer.io for the supplied user
@@ -124,7 +127,11 @@ func (c *CustomerIO) TrackAnonymousCtx(ctx context.Context, anonymousID, eventNa
 		payload["anonymous_id"] = anonymousID
 	}
 
-	return c.request(ctx, "POST", fmt.Sprintf("%s/api/v1/events", c.URL), payload)
+	u, err := buildURL(c.URL, nil, "api", "v1", "events")
+	if err != nil {
+		return err
+	}
+	return c.request(ctx, "POST", u, payload)
 }
 
 // TrackAnonymous sends a single event to Customer.io for the anonymous user
@@ -137,9 +144,11 @@ func (c *CustomerIO) DeleteCtx(ctx context.Context, customerID string) error {
 	if customerID == "" {
 		return ParamError{Param: "customerID"}
 	}
-	return c.request(ctx, "DELETE",
-		fmt.Sprintf("%s/api/v1/customers/%s", c.URL, url.PathEscape(customerID)),
-		nil)
+	u, err := buildURL(c.URL, nil, "api", "v1", "customers", customerID)
+	if err != nil {
+		return err
+	}
+	return c.request(ctx, "DELETE", u, nil)
 }
 
 func (c *CustomerIO) auth() string {
@@ -237,12 +246,14 @@ func (c *CustomerIO) MergeCustomersCtx(ctx context.Context, primary Identifier, 
 		return ParamError{Param: "secondary"}
 	}
 
-	return c.request(ctx, "POST",
-		fmt.Sprintf("%s/api/v1/merge_customers", c.URL),
-		map[string]interface{}{
-			"primary":   primary.kv(),
-			"secondary": secondary.kv(),
-		})
+	u, err := buildURL(c.URL, nil, "api", "v1", "merge_customers")
+	if err != nil {
+		return err
+	}
+	return c.request(ctx, "POST", u, map[string]interface{}{
+		"primary":   primary.kv(),
+		"secondary": secondary.kv(),
+	})
 }
 
 // MergeCustomers sends a request to Customer.io to merge two customer profiles together.

--- a/device.go
+++ b/device.go
@@ -3,7 +3,6 @@ package customerio
 import (
 	"context"
 	"fmt"
-	"net/url"
 )
 
 type deviceV1 struct {
@@ -80,9 +79,11 @@ func (c *CustomerIO) AddDeviceCtx(ctx context.Context, customerID string, device
 		"device": d,
 	}
 
-	return c.request(ctx, "PUT",
-		fmt.Sprintf("%s/api/v1/customers/%s/devices", c.URL, url.PathEscape(customerID)),
-		body)
+	u, err := buildURL(c.URL, nil, "api", "v1", "customers", customerID, "devices")
+	if err != nil {
+		return err
+	}
+	return c.request(ctx, "PUT", u, body)
 }
 
 // AddDevice adds a device for a customer
@@ -98,9 +99,11 @@ func (c *CustomerIO) DeleteDeviceCtx(ctx context.Context, customerID string, dev
 	if deviceID == "" {
 		return ParamError{Param: "deviceID"}
 	}
-	return c.request(ctx, "DELETE",
-		fmt.Sprintf("%s/api/v1/customers/%s/devices/%s", c.URL, url.PathEscape(customerID), url.PathEscape(deviceID)),
-		nil)
+	u, err := buildURL(c.URL, nil, "api", "v1", "customers", customerID, "devices", deviceID)
+	if err != nil {
+		return err
+	}
+	return c.request(ctx, "DELETE", u, nil)
 }
 
 // DeleteDevice deletes a device for a customer

--- a/options.go
+++ b/options.go
@@ -55,3 +55,12 @@ func WithUserAgent(ua string) option {
 		},
 	}
 }
+
+func WithIDType(idType string) option {
+	return option{
+		api: func(a *APIClient) {},
+		track: func(c *CustomerIO) {
+			c.IDType = idType
+		},
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -56,4 +56,10 @@ func TestTrackOptions(t *testing.T) {
 	if client.UserAgent != customUserAgent {
 		t.Errorf("wrong user-agent. got: %s, want: %s", client.UserAgent, customUserAgent)
 	}
+
+	emailIDType := "email"
+	client = customerio.NewTrackClient("site_id", "api_key", customerio.WithIDType(emailIDType))
+	if client.IDType != emailIDType {
+		t.Errorf("wrong id_type. got: %s, want: %s", client.IDType, emailIDType)
+	}
 }

--- a/segments_api.go
+++ b/segments_api.go
@@ -190,7 +190,7 @@ type ListCustomersInSegmentResponse struct {
 // CustomerIdentifier represents the customer identifiers in a segment.
 type CustomerIdentifier struct {
 	Email string `json:"email"`  // Email of the customer.
-	ID    int    `json:"id"`     // Internal ID of the customer.
+	ID    string `json:"id"`     // Internal ID of the customer.
 	CioID string `json:"cio_id"` // Customer.io ID of the customer.
 }
 

--- a/segments_api.go
+++ b/segments_api.go
@@ -1,0 +1,212 @@
+package customerio
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+const errUnexpectedStatusCode = "unexpected status code %d"
+
+// SegmentState represents the possible states of a segment.
+// Enum values:
+//   - events: currently handling event conditions for this segment
+//   - build: currently handling profile attribute conditions for this segment
+//   - events_queued: waiting to process event conditions for this segment
+//   - build_queued: waiting to process profile attribute conditions for this segment
+//   - finished: the segment has completed building
+type SegmentState string
+
+const (
+	SegmentStateEvents       SegmentState = "events"
+	SegmentStateBuild        SegmentState = "build"
+	SegmentStateEventsQueued SegmentState = "events_queued"
+	SegmentStateBuildQueued  SegmentState = "build_queued"
+	SegmentStateFinished     SegmentState = "finished"
+)
+
+// SegmentType represents the type of a segment.
+// Enum values:
+//   - dynamic: segment is dynamic, meaning it changes over time
+//   - manual: segment is manually maintained
+type SegmentType string
+
+const (
+	SegmentTypeDynamic SegmentType = "dynamic"
+	SegmentTypeManual  SegmentType = "manual"
+)
+
+// Segment represents a segment object returned by the API.
+type Segment struct {
+	ID            int          `json:"id"`                 // Unique identifier for the segment.
+	DeduplicateID string       `json:"deduplicate_id"`     // A string in the format id:timestamp.
+	Name          string       `json:"name"`               // Name of the segment.
+	Description   string       `json:"description"`        // Description of the segment's purpose.
+	State         SegmentState `json:"state"`              // Current state of the segment.
+	Progress      *int         `json:"progress,omitempty"` // Progress percentage if the segment is building.
+	Type          SegmentType  `json:"type"`               // Type of segment: dynamic or manual.
+	Tags          []string     `json:"tags,omitempty"`     // Optional tags associated with the segment.
+}
+
+// CreateSegmentRequest represents the payload to create a new segment.
+type CreateSegmentRequest struct {
+	Segment Segment `json:"segment"` // Segment data to create.
+}
+
+// CreateSegmentResponse represents the response body for a segment creation request.
+type CreateSegmentResponse struct {
+	Segment Segment `json:"segment"` // The created segment.
+}
+
+// CreateSegment sends a request to create a new segment and returns the created segment data.
+func (c *APIClient) CreateSegment(ctx context.Context, req *CreateSegmentRequest) (*CreateSegmentResponse, error) {
+	body, statusCode, err := c.doRequest(ctx, "POST", "/v1/segments", req)
+	if err != nil {
+		return nil, err
+	}
+	if statusCode != http.StatusOK {
+		return nil, fmt.Errorf(errUnexpectedStatusCode, statusCode)
+	}
+
+	var response CreateSegmentResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// ListSegmentsResponse represents the response containing multiple segments.
+type ListSegmentsResponse struct {
+	Segments []Segment `json:"segments"` // List of segments.
+}
+
+// ListSegments retrieves all segments from the API.
+func (c *APIClient) ListSegments(ctx context.Context) (*ListSegmentsResponse, error) {
+	respBody, statusCode, err := c.doRequest(ctx, "GET", "/v1/segments", nil)
+	if err != nil {
+		return nil, err
+	}
+	if statusCode != http.StatusOK {
+		return nil, fmt.Errorf(errUnexpectedStatusCode, statusCode)
+	}
+
+	var response ListSegmentsResponse
+	if err := json.Unmarshal(respBody, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// GetSegmentResponse represents the response for retrieving a single segment.
+type GetSegmentResponse struct {
+	Segment Segment `json:"segment"` // The requested segment.
+}
+
+// GetSegment retrieves a specific segment by its ID.
+func (c *APIClient) GetSegment(ctx context.Context, segmentID int) (*GetSegmentResponse, error) {
+	respBody, statusCode, err := c.doRequest(ctx, "GET", fmt.Sprintf("/v1/segments/%d", segmentID), nil)
+	if err != nil {
+		return nil, err
+	}
+	if statusCode != http.StatusOK {
+		return nil, fmt.Errorf(errUnexpectedStatusCode, statusCode)
+	}
+
+	var response GetSegmentResponse
+	if err := json.Unmarshal(respBody, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// DeleteSegment removes a segment by its ID.
+func (c *APIClient) DeleteSegment(ctx context.Context, segmentID int) error {
+	_, statusCode, err := c.doRequest(ctx, "DELETE", fmt.Sprintf("/v1/segments/%d", segmentID), nil)
+	if err != nil {
+		return err
+	}
+	if statusCode != http.StatusNoContent {
+		return fmt.Errorf(errUnexpectedStatusCode, statusCode)
+	}
+	return nil
+}
+
+// GetSegmentDependenciesResponse represents the response containing segment dependencies.
+type GetSegmentDependenciesResponse struct {
+	UsedBy struct {
+		Campaigns        []int `json:"campaigns"`         // List of campaigns using this segment.
+		SentNewsletters  []int `json:"sent_newsletters"`  // List of sent newsletters using this segment.
+		DraftNewsletters []int `json:"draft_newsletters"` // List of draft newsletters using this segment.
+	} `json:"used_by"` // Dependencies of the segment.
+}
+
+// GetSegmentDependencies returns the dependencies of a specific segment.
+func (c *APIClient) GetSegmentDependencies(ctx context.Context, segmentID int) (*GetSegmentDependenciesResponse, error) {
+	respBody, statusCode, err := c.doRequest(ctx, "GET", fmt.Sprintf("/v1/segments/%d/used_by", segmentID), nil)
+	if err != nil {
+		return nil, err
+	}
+	if statusCode != http.StatusOK {
+		return nil, fmt.Errorf(errUnexpectedStatusCode, statusCode)
+	}
+
+	var response GetSegmentDependenciesResponse
+	if err := json.Unmarshal(respBody, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// GetSegmentCustomerCountResponse represents the response for retrieving customer count in a segment.
+type GetSegmentCustomerCountResponse struct {
+	Count int `json:"count"` // Number of customers in the segment.
+}
+
+// GetSegmentCustomerCount returns the total number of customers in a specific segment.
+func (c *APIClient) GetSegmentCustomerCount(ctx context.Context, segmentID int) (*GetSegmentCustomerCountResponse, error) {
+	respBody, statusCode, err := c.doRequest(ctx, "GET", fmt.Sprintf("/v1/segments/%d/customer_count", segmentID), nil)
+	if err != nil {
+		return nil, err
+	}
+	if statusCode != http.StatusOK {
+		return nil, fmt.Errorf(errUnexpectedStatusCode, statusCode)
+	}
+
+	var response GetSegmentCustomerCountResponse
+	if err := json.Unmarshal(respBody, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// ListCustomersInSegmentResponse represents the response for listing customers in a segment.
+type ListCustomersInSegmentResponse struct {
+	IDs         []string             `json:"ids"`         // List of customer IDs.
+	Identifiers []CustomerIdentifier `json:"identifiers"` // List of customer identifiers.
+	Next        string               `json:"next"`        // Optional pagination cursor.
+}
+
+// CustomerIdentifier represents the customer identifiers in a segment.
+type CustomerIdentifier struct {
+	Email string `json:"email"`  // Email of the customer.
+	ID    int    `json:"id"`     // Internal ID of the customer.
+	CioID string `json:"cio_id"` // Customer.io ID of the customer.
+}
+
+// ListCustomersInSegment retrieves a list of customers in a specific segment.
+func (c *APIClient) ListCustomersInSegment(ctx context.Context, segmentID int) (*ListCustomersInSegmentResponse, error) {
+	respBody, statusCode, err := c.doRequest(ctx, "GET", fmt.Sprintf("/v1/segments/%d/membership", segmentID), nil)
+	if err != nil {
+		return nil, err
+	}
+	if statusCode != http.StatusOK {
+		return nil, fmt.Errorf(errUnexpectedStatusCode, statusCode)
+	}
+
+	var response ListCustomersInSegmentResponse
+	if err := json.Unmarshal(respBody, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}

--- a/segments_api.go
+++ b/segments_api.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 )
 
 const errUnexpectedStatusCode = "unexpected status code %d"
@@ -61,7 +62,7 @@ type CreateSegmentResponse struct {
 
 // CreateSegment sends a request to create a new segment and returns the created segment data.
 func (c *APIClient) CreateSegment(ctx context.Context, req *CreateSegmentRequest) (*CreateSegmentResponse, error) {
-	body, statusCode, err := c.doRequest(ctx, "POST", "/v1/segments", req)
+	body, statusCode, err := c.doRequest(ctx, "POST", req, "v1", "segments")
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +84,7 @@ type ListSegmentsResponse struct {
 
 // ListSegments retrieves all segments from the API.
 func (c *APIClient) ListSegments(ctx context.Context) (*ListSegmentsResponse, error) {
-	respBody, statusCode, err := c.doRequest(ctx, "GET", "/v1/segments", nil)
+	respBody, statusCode, err := c.doRequest(ctx, "GET", nil, "v1", "segments")
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +106,7 @@ type GetSegmentResponse struct {
 
 // GetSegment retrieves a specific segment by its ID.
 func (c *APIClient) GetSegment(ctx context.Context, segmentID int) (*GetSegmentResponse, error) {
-	respBody, statusCode, err := c.doRequest(ctx, "GET", fmt.Sprintf("/v1/segments/%d", segmentID), nil)
+	respBody, statusCode, err := c.doRequest(ctx, "GET", nil, "v1", "segments", strconv.Itoa(segmentID))
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +123,7 @@ func (c *APIClient) GetSegment(ctx context.Context, segmentID int) (*GetSegmentR
 
 // DeleteSegment removes a segment by its ID.
 func (c *APIClient) DeleteSegment(ctx context.Context, segmentID int) error {
-	_, statusCode, err := c.doRequest(ctx, "DELETE", fmt.Sprintf("/v1/segments/%d", segmentID), nil)
+	_, statusCode, err := c.doRequest(ctx, "DELETE", nil, "v1", "segments", strconv.Itoa(segmentID))
 	if err != nil {
 		return err
 	}
@@ -143,7 +144,7 @@ type GetSegmentDependenciesResponse struct {
 
 // GetSegmentDependencies returns the dependencies of a specific segment.
 func (c *APIClient) GetSegmentDependencies(ctx context.Context, segmentID int) (*GetSegmentDependenciesResponse, error) {
-	respBody, statusCode, err := c.doRequest(ctx, "GET", fmt.Sprintf("/v1/segments/%d/used_by", segmentID), nil)
+	respBody, statusCode, err := c.doRequest(ctx, "GET", nil, "v1", "segments", strconv.Itoa(segmentID), "used_by")
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +166,7 @@ type GetSegmentCustomerCountResponse struct {
 
 // GetSegmentCustomerCount returns the total number of customers in a specific segment.
 func (c *APIClient) GetSegmentCustomerCount(ctx context.Context, segmentID int) (*GetSegmentCustomerCountResponse, error) {
-	respBody, statusCode, err := c.doRequest(ctx, "GET", fmt.Sprintf("/v1/segments/%d/customer_count", segmentID), nil)
+	respBody, statusCode, err := c.doRequest(ctx, "GET", nil, "v1", "segments", strconv.Itoa(segmentID), "customer_count")
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +197,7 @@ type CustomerIdentifier struct {
 
 // ListCustomersInSegment retrieves a list of customers in a specific segment.
 func (c *APIClient) ListCustomersInSegment(ctx context.Context, segmentID int) (*ListCustomersInSegmentResponse, error) {
-	respBody, statusCode, err := c.doRequest(ctx, "GET", fmt.Sprintf("/v1/segments/%d/membership", segmentID), nil)
+	respBody, statusCode, err := c.doRequest(ctx, "GET", nil, "v1", "segments", strconv.Itoa(segmentID), "membership")
 	if err != nil {
 		return nil, err
 	}

--- a/segments_api_test.go
+++ b/segments_api_test.go
@@ -1,0 +1,623 @@
+package customerio_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/customerio/go-customerio/v3"
+)
+
+var (
+	testSegmentID     = 1
+	notFoundID        = 2
+	testDeduplicateID = "deduplicate_id"
+)
+
+func TestCreateSegment(t *testing.T) {
+	createSegmentRequest := &customerio.CreateSegmentRequest{
+		Segment: customerio.Segment{
+			Name:        "name",
+			Description: "description",
+			State:       "state",
+			Progress:    intPtr(1),
+			Type:        "type",
+			Tags:        []string{"tags"},
+		},
+	}
+
+	var verify = func(request []byte) {
+		var body customerio.CreateSegmentRequest
+		if err := json.Unmarshal(request, &body); err != nil {
+			t.Error(err)
+		}
+
+		if !reflect.DeepEqual(&body, createSegmentRequest) {
+			t.Errorf("Request differed, want: %#v, got: %#v", request, body)
+		}
+	}
+
+	api, srv := segmentsAppServer(t, verify)
+	defer srv.Close()
+
+	resp, err := api.CreateSegment(context.Background(), createSegmentRequest)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expect := &customerio.CreateSegmentResponse{
+		Segment: customerio.Segment{
+			ID:            testSegmentID,
+			DeduplicateID: testDeduplicateID,
+		},
+	}
+
+	if !reflect.DeepEqual(resp, expect) {
+		t.Errorf("Expect: %#v, Got: %#v", expect, resp)
+	}
+}
+
+func TestCreateSegmentDoRequestError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conn, _, _ := w.(http.Hijacker).Hijack()
+		conn.Close()
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	_, err := api.CreateSegment(context.Background(), &customerio.CreateSegmentRequest{
+		Segment: customerio.Segment{
+			Name:        "name",
+			Description: "description",
+			State:       "state",
+			Progress:    intPtr(1),
+			Type:        "type",
+			Tags:        []string{"tags"},
+		},
+	})
+	if err == nil {
+		t.Errorf("Expected error due to request failure, got: nil")
+	}
+}
+
+func TestCreateSegmentNotOKError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(502)
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	_, err := api.CreateSegment(context.Background(), &customerio.CreateSegmentRequest{
+		Segment: customerio.Segment{
+			Name:        "name",
+			Description: "description",
+			State:       "state",
+			Progress:    intPtr(1),
+			Type:        "type",
+			Tags:        []string{"tags"},
+		},
+	})
+	if err == nil {
+		t.Errorf("Expected error, got: %#v", err)
+	}
+}
+
+func TestCreateSegmentUnmarshalError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte(`invalid-json`))
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	_, err := api.CreateSegment(context.Background(), &customerio.CreateSegmentRequest{
+		Segment: customerio.Segment{
+			Name:        "name",
+			Description: "description",
+			State:       "state",
+			Progress:    intPtr(1),
+			Type:        "type",
+			Tags:        []string{"tags"},
+		},
+	})
+
+	if err == nil {
+		t.Errorf("Expected error due to invalid JSON, got: nil")
+	}
+}
+
+func TestListSegments(t *testing.T) {
+	var verify = func(request []byte) {}
+
+	api, srv := segmentsAppServer(t, verify)
+	defer srv.Close()
+
+	resp, err := api.ListSegments(context.Background())
+	if err != nil {
+		t.Error(err)
+	}
+
+	expect := &customerio.ListSegmentsResponse{
+		Segments: []customerio.Segment{
+			{
+				ID:            testSegmentID,
+				DeduplicateID: testDeduplicateID,
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(resp, expect) {
+		t.Errorf("Expect: %#v, Got: %#v", expect, resp)
+	}
+}
+
+func TestListSegmentsDoRequestError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conn, _, _ := w.(http.Hijacker).Hijack()
+		conn.Close()
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	_, err := api.ListSegments(context.Background())
+	if err == nil {
+		t.Errorf("Expected error due to request failure, got: nil")
+	}
+}
+
+func TestListSegmentsNotOKError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(502)
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	_, err := api.ListSegments(context.Background())
+	if err == nil {
+		t.Errorf("Expected error, got: %#v", err)
+	}
+}
+
+func TestListSegmentsUnmarshalError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte(`invalid-json`))
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	_, err := api.ListSegments(context.Background())
+	if err == nil {
+		t.Errorf("Expected error due to invalid JSON, got: nil")
+	}
+}
+
+func TestGetSegment(t *testing.T) {
+	var verify = func(request []byte) {}
+
+	api, srv := segmentsAppServer(t, verify)
+	defer srv.Close()
+
+	resp, err := api.GetSegment(context.Background(), testSegmentID)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expect := &customerio.GetSegmentResponse{
+		Segment: customerio.Segment{
+			ID:            testSegmentID,
+			DeduplicateID: testDeduplicateID,
+		},
+	}
+
+	if !reflect.DeepEqual(resp, expect) {
+		t.Errorf("Expect: %#v, Got: %#v", expect, resp)
+	}
+}
+
+func TestGetSegmentDoRequestError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conn, _, _ := w.(http.Hijacker).Hijack()
+		conn.Close()
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	_, err := api.GetSegment(context.Background(), testSegmentID)
+	if err == nil {
+		t.Errorf("Expected error due to request failure, got: nil")
+	}
+}
+
+func TestGetSegmentNotOKError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(502)
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	_, err := api.GetSegment(context.Background(), testSegmentID)
+	if err == nil {
+		t.Errorf("Expected error, got: %#v", err)
+	}
+}
+
+func TestGetSegmentUnmarshalError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte(`invalid-json`))
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	_, err := api.GetSegment(context.Background(), testSegmentID)
+	if err == nil {
+		t.Errorf("Expected error due to invalid JSON, got: nil")
+	}
+}
+
+func TestDeleteSegment(t *testing.T) {
+	var verify = func(request []byte) {}
+
+	api, srv := segmentsAppServer(t, verify)
+	defer srv.Close()
+
+	err := api.DeleteSegment(context.Background(), testSegmentID)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestDeleteSegmentDoRequestError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conn, _, _ := w.(http.Hijacker).Hijack()
+		conn.Close()
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	err := api.DeleteSegment(context.Background(), testSegmentID)
+	if err == nil {
+		t.Errorf("Expected error due to request failure, got: nil")
+	}
+}
+
+func TestDeleteSegmentNotOKError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(502)
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	err := api.DeleteSegment(context.Background(), testSegmentID)
+	if err == nil {
+		t.Errorf("Expected error, got: %#v", err)
+	}
+}
+
+func TestDeleteSegmentUnmarshalError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte(`invalid-json`))
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	err := api.DeleteSegment(context.Background(), testSegmentID)
+	if err == nil {
+		t.Errorf("Expected error due to invalid JSON, got: nil")
+	}
+}
+
+func TestGetSegmentDependencies(t *testing.T) {
+	var verify = func(request []byte) {}
+
+	api, srv := segmentsAppServer(t, verify)
+	defer srv.Close()
+
+	resp, err := api.GetSegmentDependencies(context.Background(), testSegmentID)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expect := &customerio.GetSegmentDependenciesResponse{
+		UsedBy: struct {
+			Campaigns        []int `json:"campaigns"`
+			SentNewsletters  []int `json:"sent_newsletters"`
+			DraftNewsletters []int `json:"draft_newsletters"`
+		}{
+			Campaigns:        []int{1},
+			SentNewsletters:  []int{2},
+			DraftNewsletters: []int{3},
+		},
+	}
+
+	if !reflect.DeepEqual(resp, expect) {
+		t.Errorf("Expect: %#v, Got: %#v", expect, resp)
+	}
+}
+
+func TestGetSegmentDependenciesDoRequestError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conn, _, _ := w.(http.Hijacker).Hijack()
+		conn.Close()
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	_, err := api.GetSegmentDependencies(context.Background(), testSegmentID)
+	if err == nil {
+		t.Errorf("Expected error due to request failure, got: nil")
+	}
+}
+
+func TestGetSegmentDependenciesNotOKError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(502)
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	_, err := api.GetSegmentDependencies(context.Background(), testSegmentID)
+	if err == nil {
+		t.Errorf("Expected error, got: %#v", err)
+	}
+}
+
+func TestGetSegmentDependenciesUnmarshalError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte(`invalid-json`))
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	_, err := api.GetSegmentDependencies(context.Background(), testSegmentID)
+	if err == nil {
+		t.Errorf("Expected error due to invalid JSON, got: nil")
+	}
+}
+
+func TestGetSegmentCustomerCount(t *testing.T) {
+	var verify = func(request []byte) {}
+
+	api, srv := segmentsAppServer(t, verify)
+	defer srv.Close()
+
+	resp, err := api.GetSegmentCustomerCount(context.Background(), testSegmentID)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expect := &customerio.GetSegmentCustomerCountResponse{
+		Count: 1,
+	}
+
+	if !reflect.DeepEqual(resp, expect) {
+		t.Errorf("Expect: %#v, Got: %#v", expect, resp)
+	}
+}
+
+func TestGetSegmentCustomerCountDoRequestError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conn, _, _ := w.(http.Hijacker).Hijack()
+		conn.Close()
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	_, err := api.GetSegmentCustomerCount(context.Background(), testSegmentID)
+	if err == nil {
+		t.Errorf("Expected error due to request failure, got: nil")
+	}
+}
+
+func TestGetSegmentCustomerCountNotOKError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(502)
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	_, err := api.GetSegmentCustomerCount(context.Background(), testSegmentID)
+	if err == nil {
+		t.Errorf("Expected error, got: %#v", err)
+	}
+}
+
+func TestGetSegmentCustomerCountUnmarshalError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte(`invalid-json`))
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	_, err := api.GetSegmentCustomerCount(context.Background(), testSegmentID)
+	if err == nil {
+		t.Errorf("Expected error due to invalid JSON, got: nil")
+	}
+}
+
+func TestListCustomersInSegment(t *testing.T) {
+	var verify = func(request []byte) {}
+
+	api, srv := segmentsAppServer(t, verify)
+	defer srv.Close()
+
+	resp, err := api.ListCustomersInSegment(context.Background(), testSegmentID)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expect := &customerio.ListCustomersInSegmentResponse{
+		IDs: []string{"string"},
+		Identifiers: []customerio.CustomerIdentifier{
+			{
+				Email: "test@example.com",
+				ID:    2,
+				CioID: "a3000001",
+			},
+		},
+		Next: "string",
+	}
+
+	if !reflect.DeepEqual(resp, expect) {
+		t.Errorf("Expect: %#v, Got: %#v", expect, resp)
+	}
+}
+
+func TestListCustomersInSegmentDoRequestError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conn, _, _ := w.(http.Hijacker).Hijack()
+		conn.Close()
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	_, err := api.ListCustomersInSegment(context.Background(), testSegmentID)
+	if err == nil {
+		t.Errorf("Expected error due to request failure, got: nil")
+	}
+}
+
+func TestListCustomersInSegmentNotOKError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(502)
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	_, err := api.ListCustomersInSegment(context.Background(), testSegmentID)
+	if err == nil {
+		t.Errorf("Expected error, got: %#v", err)
+	}
+}
+
+func TestListCustomersInSegmentUnmarshalError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte(`invalid-json`))
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	_, err := api.ListCustomersInSegment(context.Background(), testSegmentID)
+	if err == nil {
+		t.Errorf("Expected error due to invalid JSON, got: nil")
+	}
+}
+
+func intPtr(s int) *int {
+	return &s
+}
+
+func segmentsAppServer(t *testing.T, verify func(request []byte)) (*customerio.APIClient, *httptest.Server) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		b, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			t.Error(err)
+		}
+		defer req.Body.Close()
+
+		verify(b)
+
+		switch true {
+		case req.Method == "POST" && req.URL.Path == "/v1/segments":
+			w.Write([]byte(`{
+				"segment": {
+					"id": ` + fmt.Sprintf("%d", testSegmentID) + `,
+					"deduplicate_id": "` + testDeduplicateID + `"
+			}
+		  }`))
+		case req.Method == "GET" && req.URL.Path == "/v1/segments":
+			w.Write([]byte(`{
+				"segments": [
+					{
+						"id": ` + fmt.Sprintf("%d", testSegmentID) + `,
+						"deduplicate_id": "` + testDeduplicateID + `"
+			}
+		  ]}`))
+		case req.Method == "GET" && req.URL.Path == "/v1/segments/1":
+			w.Write([]byte(`{
+				"segment": {
+					"id": ` + fmt.Sprintf("%d", testSegmentID) + `,
+					"deduplicate_id": "` + testDeduplicateID + `"
+			}
+		  }`))
+		case req.Method == "DELETE" && req.URL.Path == "/v1/segments/1":
+			w.WriteHeader(http.StatusNoContent)
+		case req.Method == "GET" && req.URL.Path == "/v1/segments/1/customer_count":
+			w.Write([]byte(`{
+				"count": 1
+			}`))
+		case req.Method == "GET" && req.URL.Path == "/v1/segments/1/membership":
+			w.Write([]byte(`{
+				"ids": ["string"],
+				"identifiers": [
+					{
+						"email": "test@example.com",
+						"id": 2,
+						"cio_id": "a3000001"
+					}
+				],
+				"next": "string"
+			}`))
+		case req.Method == "GET" && req.URL.Path == "/v1/segments/1/used_by":
+			w.Write([]byte(`{
+				"used_by": {
+					"campaigns": [1],
+					"sent_newsletters": [2],
+					"draft_newsletters": [3]
+				}
+			}`))
+		default:
+			t.Errorf("Unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+	}))
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	return api, srv
+}

--- a/segments_api_test.go
+++ b/segments_api_test.go
@@ -490,7 +490,7 @@ func TestListCustomersInSegment(t *testing.T) {
 		Identifiers: []customerio.CustomerIdentifier{
 			{
 				Email: "test@example.com",
-				ID:    2,
+				ID:    "test@example.com",
 				CioID: "a3000001",
 			},
 		},
@@ -597,7 +597,7 @@ func segmentsAppServer(t *testing.T, verify func(request []byte)) (*customerio.A
 				"identifiers": [
 					{
 						"email": "test@example.com",
-						"id": 2,
+						"id": "test@example.com",
 						"cio_id": "a3000001"
 					}
 				],

--- a/segments_customerio.go
+++ b/segments_customerio.go
@@ -1,0 +1,36 @@
+package customerio
+
+import (
+	"context"
+	"fmt"
+)
+
+// AddPeopleToSegment adds people to a segment.
+func (c *CustomerIO) AddPeopleToSegment(ctx context.Context, segmentID int, ids []string) error {
+	if segmentID == 0 {
+		return ParamError{Param: "segmentID"}
+	}
+	if len(ids) == 0 {
+		return ParamError{Param: "ids"}
+	}
+	return c.request(ctx, "POST",
+		fmt.Sprintf("%s/api/v1/segments/%d/add_customers", c.URL, segmentID),
+		map[string]interface{}{
+			"ids": ids,
+		})
+}
+
+// RemovePeopleFromSegment removes people from a segment
+func (c *CustomerIO) RemovePeopleFromSegment(ctx context.Context, segmentID int, ids []string) error {
+	if segmentID == 0 {
+		return ParamError{Param: "segmentID"}
+	}
+	if len(ids) == 0 {
+		return ParamError{Param: "ids"}
+	}
+	return c.request(ctx, "DELETE",
+		fmt.Sprintf("%s/api/v1/segments/%d/remove_customers", c.URL, segmentID),
+		map[string]interface{}{
+			"ids": ids,
+		})
+}

--- a/segments_customerio.go
+++ b/segments_customerio.go
@@ -28,7 +28,7 @@ func (c *CustomerIO) RemovePeopleFromSegment(ctx context.Context, segmentID int,
 	if len(ids) == 0 {
 		return ParamError{Param: "ids"}
 	}
-	return c.request(ctx, "DELETE",
+	return c.request(ctx, "POST",
 		fmt.Sprintf("%s/api/v1/segments/%d/remove_customers", c.URL, segmentID),
 		map[string]interface{}{
 			"ids": ids,

--- a/segments_customerio.go
+++ b/segments_customerio.go
@@ -22,7 +22,7 @@ const (
 )
 
 // AddPeopleToSegment adds people to a segment.
-func (c *CustomerIO) AddPeopleToSegment(ctx context.Context, segmentID int, idType string, ids []string) error {
+func (c *CustomerIO) AddPeopleToSegment(ctx context.Context, segmentID int, ids []string) error {
 	if segmentID == 0 {
 		return ParamError{Param: "segmentID"}
 	}
@@ -30,14 +30,14 @@ func (c *CustomerIO) AddPeopleToSegment(ctx context.Context, segmentID int, idTy
 		return ParamError{Param: "ids"}
 	}
 	return c.request(ctx, "POST",
-		fmt.Sprintf("%s/api/v1/segments/%d/add_customers?id_type=%s", c.URL, segmentID, c.getValidIDType(idType)),
+		fmt.Sprintf("%s/api/v1/segments/%d/add_customers%s", c.URL, segmentID, c.getQueryParams()),
 		map[string]interface{}{
 			"ids": ids,
 		})
 }
 
 // RemovePeopleFromSegment removes people from a segment
-func (c *CustomerIO) RemovePeopleFromSegment(ctx context.Context, segmentID int, idType string, ids []string) error {
+func (c *CustomerIO) RemovePeopleFromSegment(ctx context.Context, segmentID int, ids []string) error {
 	if segmentID == 0 {
 		return ParamError{Param: "segmentID"}
 	}
@@ -45,18 +45,23 @@ func (c *CustomerIO) RemovePeopleFromSegment(ctx context.Context, segmentID int,
 		return ParamError{Param: "ids"}
 	}
 	return c.request(ctx, "POST",
-		fmt.Sprintf("%s/api/v1/segments/%d/remove_customers?id_type=%s", c.URL, segmentID, c.getValidIDType(idType)),
+		fmt.Sprintf("%s/api/v1/segments/%d/remove_customers%s", c.URL, segmentID, c.getQueryParams()),
 		map[string]interface{}{
 			"ids": ids,
 		})
 }
 
-// getValidIDType returns the valid IDType or defaults to IDTypeID
-func (c *CustomerIO) getValidIDType(idType string) IDType {
-	switch IDType(idType) {
+// getQueryParams returns the query parameter for the request.
+func (c *CustomerIO) getQueryParams() string {
+	if c.IDType == "" {
+		return ""
+	}
+
+	// Check if the IDType is valid and construct query parameter accordingly
+	switch IDType(c.IDType) {
 	case IDTypeEmail, IDTypeCioID:
-		return IDType(idType)
+		return fmt.Sprintf("?id_type=%s", c.IDType)
 	default:
-		return DefaultIDType
+		return fmt.Sprintf("?id_type=%s", DefaultIDType)
 	}
 }

--- a/segments_customerio.go
+++ b/segments_customerio.go
@@ -5,8 +5,24 @@ import (
 	"fmt"
 )
 
+// IDType is the type of ids you want to use.
+// All the values in the ids array must be of this type.
+// If you don't provide this parameter, we assume that the ids array contains id values.
+// Enum values:
+//   - "id"
+//   - "email"
+//   - "cio_id"
+type IDType string
+
+const (
+	IDTypeID      IDType = "id"
+	IDTypeEmail   IDType = "email"
+	IDTypeCioID   IDType = "cio_id"
+	DefaultIDType        = IDTypeID
+)
+
 // AddPeopleToSegment adds people to a segment.
-func (c *CustomerIO) AddPeopleToSegment(ctx context.Context, segmentID int, ids []string) error {
+func (c *CustomerIO) AddPeopleToSegment(ctx context.Context, segmentID int, idType string, ids []string) error {
 	if segmentID == 0 {
 		return ParamError{Param: "segmentID"}
 	}
@@ -14,14 +30,14 @@ func (c *CustomerIO) AddPeopleToSegment(ctx context.Context, segmentID int, ids 
 		return ParamError{Param: "ids"}
 	}
 	return c.request(ctx, "POST",
-		fmt.Sprintf("%s/api/v1/segments/%d/add_customers", c.URL, segmentID),
+		fmt.Sprintf("%s/api/v1/segments/%d/add_customers?id_type=%s", c.URL, segmentID, c.getValidIDType(idType)),
 		map[string]interface{}{
 			"ids": ids,
 		})
 }
 
 // RemovePeopleFromSegment removes people from a segment
-func (c *CustomerIO) RemovePeopleFromSegment(ctx context.Context, segmentID int, ids []string) error {
+func (c *CustomerIO) RemovePeopleFromSegment(ctx context.Context, segmentID int, idType string, ids []string) error {
 	if segmentID == 0 {
 		return ParamError{Param: "segmentID"}
 	}
@@ -29,8 +45,18 @@ func (c *CustomerIO) RemovePeopleFromSegment(ctx context.Context, segmentID int,
 		return ParamError{Param: "ids"}
 	}
 	return c.request(ctx, "POST",
-		fmt.Sprintf("%s/api/v1/segments/%d/remove_customers", c.URL, segmentID),
+		fmt.Sprintf("%s/api/v1/segments/%d/remove_customers?id_type=%s", c.URL, segmentID, c.getValidIDType(idType)),
 		map[string]interface{}{
 			"ids": ids,
 		})
+}
+
+// getValidIDType returns the valid IDType or defaults to IDTypeID
+func (c *CustomerIO) getValidIDType(idType string) IDType {
+	switch IDType(idType) {
+	case IDTypeEmail, IDTypeCioID:
+		return IDType(idType)
+	default:
+		return DefaultIDType
+	}
 }

--- a/segments_customerio.go
+++ b/segments_customerio.go
@@ -2,7 +2,8 @@ package customerio
 
 import (
 	"context"
-	"fmt"
+	"net/url"
+	"strconv"
 )
 
 // IDType is the type of ids you want to use.
@@ -29,11 +30,13 @@ func (c *CustomerIO) AddPeopleToSegment(ctx context.Context, segmentID int, ids 
 	if len(ids) == 0 {
 		return ParamError{Param: "ids"}
 	}
-	return c.request(ctx, "POST",
-		fmt.Sprintf("%s/api/v1/segments/%d/add_customers%s", c.URL, segmentID, c.getQueryParams()),
-		map[string]interface{}{
-			"ids": ids,
-		})
+	u, err := buildURL(c.URL, c.idTypeQuery(), "api", "v1", "segments", strconv.Itoa(segmentID), "add_customers")
+	if err != nil {
+		return err
+	}
+	return c.request(ctx, "POST", u, map[string]interface{}{
+		"ids": ids,
+	})
 }
 
 // RemovePeopleFromSegment removes people from a segment
@@ -44,24 +47,29 @@ func (c *CustomerIO) RemovePeopleFromSegment(ctx context.Context, segmentID int,
 	if len(ids) == 0 {
 		return ParamError{Param: "ids"}
 	}
-	return c.request(ctx, "POST",
-		fmt.Sprintf("%s/api/v1/segments/%d/remove_customers%s", c.URL, segmentID, c.getQueryParams()),
-		map[string]interface{}{
-			"ids": ids,
-		})
+	u, err := buildURL(c.URL, c.idTypeQuery(), "api", "v1", "segments", strconv.Itoa(segmentID), "remove_customers")
+	if err != nil {
+		return err
+	}
+	return c.request(ctx, "POST", u, map[string]interface{}{
+		"ids": ids,
+	})
 }
 
-// getQueryParams returns the query parameter for the request.
-func (c *CustomerIO) getQueryParams() string {
+// idTypeQuery returns the id_type query parameter for segment requests, or nil
+// when no IDType is configured.
+func (c *CustomerIO) idTypeQuery() url.Values {
 	if c.IDType == "" {
-		return ""
+		return nil
 	}
 
-	// Check if the IDType is valid and construct query parameter accordingly
+	// Check if the IDType is valid and construct the query parameter accordingly.
+	v := url.Values{}
 	switch IDType(c.IDType) {
 	case IDTypeEmail, IDTypeCioID:
-		return fmt.Sprintf("?id_type=%s", c.IDType)
+		v.Set("id_type", c.IDType)
 	default:
-		return fmt.Sprintf("?id_type=%s", DefaultIDType)
+		v.Set("id_type", string(DefaultIDType))
 	}
+	return v
 }

--- a/segments_customerio_test.go
+++ b/segments_customerio_test.go
@@ -1,0 +1,169 @@
+package customerio_test
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/customerio/go-customerio/v3"
+)
+
+func TestAddPeopleToSegment(t *testing.T) {
+	customerIDs := []string{"1", "2", "3"}
+	var verify = func(request []byte) {}
+
+	api, srv := segmentsTrackServer(t, verify)
+	defer srv.Close()
+
+	err := api.AddPeopleToSegment(context.Background(), testSegmentID, customerIDs)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestAddPeopleToSegmentSegmentParamError(t *testing.T) {
+	var customerIDs []string
+	var verify = func(request []byte) {}
+
+	api, srv := segmentsTrackServer(t, verify)
+	defer srv.Close()
+
+	err := api.AddPeopleToSegment(context.Background(), 0, customerIDs)
+	if err == nil {
+		t.Errorf("Expected error, got: %#v", err)
+	}
+
+	if e, ok := err.(customerio.ParamError); !ok {
+		t.Errorf("Expected ParamError, got: %#v", e)
+	}
+}
+
+func TestAddPeopleToSegmentIDsParamError(t *testing.T) {
+	var customerIDs []string
+	var verify = func(request []byte) {}
+
+	api, srv := segmentsTrackServer(t, verify)
+	defer srv.Close()
+
+	err := api.AddPeopleToSegment(context.Background(), testSegmentID, customerIDs)
+	if err == nil {
+		t.Errorf("Expected error, got: %#v", err)
+	}
+
+	if e, ok := err.(customerio.ParamError); !ok {
+		t.Errorf("Expected ParamError, got: %#v", e)
+	}
+}
+
+func TestAddPeopleToSegmentError(t *testing.T) {
+	customerIDs := []string{"1", "2", "3"}
+	var verify = func(request []byte) {}
+
+	api, srv := segmentsTrackServer(t, verify)
+	defer srv.Close()
+
+	err := api.AddPeopleToSegment(context.Background(), notFoundID, customerIDs)
+	if err == nil {
+		t.Errorf("Expected error, got: %#v", err)
+	}
+
+	if e, ok := err.(*customerio.CustomerIOError); !ok {
+		t.Errorf("Expected CustomerIOError, got: %#v", e)
+	}
+}
+
+func segmentsTrackServer(t *testing.T, verify func(request []byte)) (*customerio.CustomerIO, *httptest.Server) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		b, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			t.Error(err)
+		}
+		defer req.Body.Close()
+
+		verify(b)
+
+		switch true {
+		case req.Method == "POST" && req.URL.Path == "/api/v1/segments/1/add_customers":
+			w.WriteHeader(http.StatusOK)
+		case req.Method == "POST" && req.URL.Path == "/api/v1/segments/2/add_customers":
+			w.WriteHeader(http.StatusNotFound)
+		case req.Method == "DELETE" && req.URL.Path == "/api/v1/segments/1/remove_customers":
+			w.WriteHeader(http.StatusOK)
+		case req.Method == "DELETE" && req.URL.Path == "/api/v1/segments/2/remove_customers":
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			t.Errorf("Unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+	}))
+
+	api := customerio.NewCustomerIO("test", "myKey")
+	api.URL = srv.URL
+
+	return api, srv
+}
+
+func TestRemovePeopleFromSegment(t *testing.T) {
+	customerIDs := []string{"1", "2", "3"}
+	var verify = func(request []byte) {}
+
+	api, srv := segmentsTrackServer(t, verify)
+	defer srv.Close()
+
+	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, customerIDs)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestRemovePeopleFromSegmentSegmentParamError(t *testing.T) {
+	var customerIDs []string
+	var verify = func(request []byte) {}
+
+	api, srv := segmentsTrackServer(t, verify)
+	defer srv.Close()
+
+	err := api.RemovePeopleFromSegment(context.Background(), 0, customerIDs)
+	if err == nil {
+		t.Errorf("Expected error, got: %#v", err)
+	}
+
+	if e, ok := err.(customerio.ParamError); !ok {
+		t.Errorf("Expected ParamError, got: %#v", e)
+	}
+}
+
+func TestRemovePeopleFromSegmentIDsParamError(t *testing.T) {
+	var customerIDs []string
+	var verify = func(request []byte) {}
+
+	api, srv := segmentsTrackServer(t, verify)
+	defer srv.Close()
+
+	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, customerIDs)
+	if err == nil {
+		t.Errorf("Expected error, got: %#v", err)
+	}
+
+	if e, ok := err.(customerio.ParamError); !ok {
+		t.Errorf("Expected ParamError, got: %#v", e)
+	}
+}
+
+func TestRemovePeopleFromSegmentError(t *testing.T) {
+	customerIDs := []string{"1", "2", "3"}
+	var verify = func(request []byte) {}
+
+	api, srv := segmentsTrackServer(t, verify)
+	defer srv.Close()
+
+	err := api.RemovePeopleFromSegment(context.Background(), notFoundID, customerIDs)
+	if err == nil {
+		t.Errorf("Expected error, got: %#v", err)
+	}
+
+	if e, ok := err.(*customerio.CustomerIOError); !ok {
+		t.Errorf("Expected CustomerIOError, got: %#v", e)
+	}
+}

--- a/segments_customerio_test.go
+++ b/segments_customerio_test.go
@@ -89,9 +89,9 @@ func segmentsTrackServer(t *testing.T, verify func(request []byte)) (*customerio
 			w.WriteHeader(http.StatusOK)
 		case req.Method == "POST" && req.URL.Path == "/api/v1/segments/2/add_customers":
 			w.WriteHeader(http.StatusNotFound)
-		case req.Method == "DELETE" && req.URL.Path == "/api/v1/segments/1/remove_customers":
+		case req.Method == "POST" && req.URL.Path == "/api/v1/segments/1/remove_customers":
 			w.WriteHeader(http.StatusOK)
-		case req.Method == "DELETE" && req.URL.Path == "/api/v1/segments/2/remove_customers":
+		case req.Method == "POST" && req.URL.Path == "/api/v1/segments/2/remove_customers":
 			w.WriteHeader(http.StatusNotFound)
 		default:
 			t.Errorf("Unexpected request: %s %s", req.Method, req.URL.Path)

--- a/segments_customerio_test.go
+++ b/segments_customerio_test.go
@@ -2,7 +2,6 @@ package customerio_test
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -12,12 +11,53 @@ import (
 
 func TestAddPeopleToSegment(t *testing.T) {
 	customerIDs := []string{"1", "2", "3"}
-	var verify = func(request []byte) {}
+	var verify = func(req *http.Request) {
+		idType := req.URL.Query().Get("id_type")
+		if idType != "id" {
+			t.Errorf("Expected id_type to be 'id', got '%s'", idType)
+		}
+	}
 
 	api, srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.AddPeopleToSegment(context.Background(), testSegmentID, customerIDs)
+	err := api.AddPeopleToSegment(context.Background(), testSegmentID, "id", customerIDs)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestAddPeopleToSegmentEmailIDType(t *testing.T) {
+	customerIDs := []string{"1", "2", "3"}
+	var verify = func(req *http.Request) {
+		idType := req.URL.Query().Get("id_type")
+		if idType != "email" {
+			t.Errorf("Expected id_type to be 'email', got '%s'", idType)
+		}
+	}
+
+	api, srv := segmentsTrackServer(t, verify)
+	defer srv.Close()
+
+	err := api.AddPeopleToSegment(context.Background(), testSegmentID, "email", customerIDs)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestAddPeopleToSegmentCioIDType(t *testing.T) {
+	customerIDs := []string{"1", "2", "3"}
+	var verify = func(req *http.Request) {
+		idType := req.URL.Query().Get("id_type")
+		if idType != "cio_id" {
+			t.Errorf("Expected id_type to be 'cio_id', got '%s'", idType)
+		}
+	}
+
+	api, srv := segmentsTrackServer(t, verify)
+	defer srv.Close()
+
+	err := api.AddPeopleToSegment(context.Background(), testSegmentID, "cio_id", customerIDs)
 	if err != nil {
 		t.Error(err)
 	}
@@ -25,12 +65,12 @@ func TestAddPeopleToSegment(t *testing.T) {
 
 func TestAddPeopleToSegmentSegmentParamError(t *testing.T) {
 	var customerIDs []string
-	var verify = func(request []byte) {}
+	var verify = func(req *http.Request) {}
 
 	api, srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.AddPeopleToSegment(context.Background(), 0, customerIDs)
+	err := api.AddPeopleToSegment(context.Background(), 0, "id", customerIDs)
 	if err == nil {
 		t.Errorf("Expected error, got: %#v", err)
 	}
@@ -42,12 +82,12 @@ func TestAddPeopleToSegmentSegmentParamError(t *testing.T) {
 
 func TestAddPeopleToSegmentIDsParamError(t *testing.T) {
 	var customerIDs []string
-	var verify = func(request []byte) {}
+	var verify = func(req *http.Request) {}
 
 	api, srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.AddPeopleToSegment(context.Background(), testSegmentID, customerIDs)
+	err := api.AddPeopleToSegment(context.Background(), testSegmentID, "id", customerIDs)
 	if err == nil {
 		t.Errorf("Expected error, got: %#v", err)
 	}
@@ -59,12 +99,12 @@ func TestAddPeopleToSegmentIDsParamError(t *testing.T) {
 
 func TestAddPeopleToSegmentError(t *testing.T) {
 	customerIDs := []string{"1", "2", "3"}
-	var verify = func(request []byte) {}
+	var verify = func(req *http.Request) {}
 
 	api, srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.AddPeopleToSegment(context.Background(), notFoundID, customerIDs)
+	err := api.AddPeopleToSegment(context.Background(), notFoundID, "id", customerIDs)
 	if err == nil {
 		t.Errorf("Expected error, got: %#v", err)
 	}
@@ -74,15 +114,9 @@ func TestAddPeopleToSegmentError(t *testing.T) {
 	}
 }
 
-func segmentsTrackServer(t *testing.T, verify func(request []byte)) (*customerio.CustomerIO, *httptest.Server) {
+func segmentsTrackServer(t *testing.T, verify func(req *http.Request)) (*customerio.CustomerIO, *httptest.Server) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		b, err := ioutil.ReadAll(req.Body)
-		if err != nil {
-			t.Error(err)
-		}
-		defer req.Body.Close()
-
-		verify(b)
+		verify(req)
 
 		switch true {
 		case req.Method == "POST" && req.URL.Path == "/api/v1/segments/1/add_customers":
@@ -106,12 +140,53 @@ func segmentsTrackServer(t *testing.T, verify func(request []byte)) (*customerio
 
 func TestRemovePeopleFromSegment(t *testing.T) {
 	customerIDs := []string{"1", "2", "3"}
-	var verify = func(request []byte) {}
+	var verify = func(req *http.Request) {
+		idType := req.URL.Query().Get("id_type")
+		if idType != "id" {
+			t.Errorf("Expected id_type to be 'id', got '%s'", idType)
+		}
+	}
 
 	api, srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, customerIDs)
+	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, "id", customerIDs)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestRemovePeopleToSegmentEmailIDType(t *testing.T) {
+	customerIDs := []string{"1", "2", "3"}
+	var verify = func(req *http.Request) {
+		idType := req.URL.Query().Get("id_type")
+		if idType != "email" {
+			t.Errorf("Expected id_type to be 'email', got '%s'", idType)
+		}
+	}
+
+	api, srv := segmentsTrackServer(t, verify)
+	defer srv.Close()
+
+	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, "email", customerIDs)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestRemovePeopleToSegmentCioIDType(t *testing.T) {
+	customerIDs := []string{"1", "2", "3"}
+	var verify = func(req *http.Request) {
+		idType := req.URL.Query().Get("id_type")
+		if idType != "cio_id" {
+			t.Errorf("Expected id_type to be 'cio_id', got '%s'", idType)
+		}
+	}
+
+	api, srv := segmentsTrackServer(t, verify)
+	defer srv.Close()
+
+	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, "cio_id", customerIDs)
 	if err != nil {
 		t.Error(err)
 	}
@@ -119,12 +194,12 @@ func TestRemovePeopleFromSegment(t *testing.T) {
 
 func TestRemovePeopleFromSegmentSegmentParamError(t *testing.T) {
 	var customerIDs []string
-	var verify = func(request []byte) {}
+	var verify = func(req *http.Request) {}
 
 	api, srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.RemovePeopleFromSegment(context.Background(), 0, customerIDs)
+	err := api.RemovePeopleFromSegment(context.Background(), 0, "id", customerIDs)
 	if err == nil {
 		t.Errorf("Expected error, got: %#v", err)
 	}
@@ -136,12 +211,12 @@ func TestRemovePeopleFromSegmentSegmentParamError(t *testing.T) {
 
 func TestRemovePeopleFromSegmentIDsParamError(t *testing.T) {
 	var customerIDs []string
-	var verify = func(request []byte) {}
+	var verify = func(req *http.Request) {}
 
 	api, srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, customerIDs)
+	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, "id", customerIDs)
 	if err == nil {
 		t.Errorf("Expected error, got: %#v", err)
 	}
@@ -153,12 +228,12 @@ func TestRemovePeopleFromSegmentIDsParamError(t *testing.T) {
 
 func TestRemovePeopleFromSegmentError(t *testing.T) {
 	customerIDs := []string{"1", "2", "3"}
-	var verify = func(request []byte) {}
+	var verify = func(req *http.Request) {}
 
 	api, srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.RemovePeopleFromSegment(context.Background(), notFoundID, customerIDs)
+	err := api.RemovePeopleFromSegment(context.Background(), notFoundID, "id", customerIDs)
 	if err == nil {
 		t.Errorf("Expected error, got: %#v", err)
 	}

--- a/segments_customerio_test.go
+++ b/segments_customerio_test.go
@@ -11,17 +11,15 @@ import (
 
 func TestAddPeopleToSegment(t *testing.T) {
 	customerIDs := []string{"1", "2", "3"}
-	var verify = func(req *http.Request) {
-		idType := req.URL.Query().Get("id_type")
-		if idType != "id" {
-			t.Errorf("Expected id_type to be 'id', got '%s'", idType)
-		}
-	}
+	var verify = func(req *http.Request) {}
 
-	api, srv := segmentsTrackServer(t, verify)
+	srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.AddPeopleToSegment(context.Background(), testSegmentID, "id", customerIDs)
+	api := customerio.NewTrackClient("test", "myKey")
+	api.URL = srv.URL
+
+	err := api.AddPeopleToSegment(context.Background(), testSegmentID, customerIDs)
 	if err != nil {
 		t.Error(err)
 	}
@@ -36,10 +34,13 @@ func TestAddPeopleToSegmentEmailIDType(t *testing.T) {
 		}
 	}
 
-	api, srv := segmentsTrackServer(t, verify)
+	srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.AddPeopleToSegment(context.Background(), testSegmentID, "email", customerIDs)
+	api := customerio.NewTrackClient("test", "myKey", customerio.WithIDType("email"))
+	api.URL = srv.URL
+
+	err := api.AddPeopleToSegment(context.Background(), testSegmentID, customerIDs)
 	if err != nil {
 		t.Error(err)
 	}
@@ -54,10 +55,34 @@ func TestAddPeopleToSegmentCioIDType(t *testing.T) {
 		}
 	}
 
-	api, srv := segmentsTrackServer(t, verify)
+	srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.AddPeopleToSegment(context.Background(), testSegmentID, "cio_id", customerIDs)
+	api := customerio.NewTrackClient("test", "myKey", customerio.WithIDType("cio_id"))
+	api.URL = srv.URL
+
+	err := api.AddPeopleToSegment(context.Background(), testSegmentID, customerIDs)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestAddPeopleToSegmentInvalidIDType(t *testing.T) {
+	customerIDs := []string{"1", "2", "3"}
+	var verify = func(req *http.Request) {
+		idType := req.URL.Query().Get("id_type")
+		if idType != "id" {
+			t.Errorf("Expected id_type to be 'id', got '%s'", idType)
+		}
+	}
+
+	srv := segmentsTrackServer(t, verify)
+	defer srv.Close()
+
+	api := customerio.NewTrackClient("test", "myKey", customerio.WithIDType("invalid"))
+	api.URL = srv.URL
+
+	err := api.AddPeopleToSegment(context.Background(), testSegmentID, customerIDs)
 	if err != nil {
 		t.Error(err)
 	}
@@ -67,10 +92,13 @@ func TestAddPeopleToSegmentSegmentParamError(t *testing.T) {
 	var customerIDs []string
 	var verify = func(req *http.Request) {}
 
-	api, srv := segmentsTrackServer(t, verify)
+	srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.AddPeopleToSegment(context.Background(), 0, "id", customerIDs)
+	api := customerio.NewTrackClient("test", "myKey")
+	api.URL = srv.URL
+
+	err := api.AddPeopleToSegment(context.Background(), 0, customerIDs)
 	if err == nil {
 		t.Errorf("Expected error, got: %#v", err)
 	}
@@ -84,10 +112,13 @@ func TestAddPeopleToSegmentIDsParamError(t *testing.T) {
 	var customerIDs []string
 	var verify = func(req *http.Request) {}
 
-	api, srv := segmentsTrackServer(t, verify)
+	srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.AddPeopleToSegment(context.Background(), testSegmentID, "id", customerIDs)
+	api := customerio.NewTrackClient("test", "myKey")
+	api.URL = srv.URL
+
+	err := api.AddPeopleToSegment(context.Background(), testSegmentID, customerIDs)
 	if err == nil {
 		t.Errorf("Expected error, got: %#v", err)
 	}
@@ -101,10 +132,13 @@ func TestAddPeopleToSegmentError(t *testing.T) {
 	customerIDs := []string{"1", "2", "3"}
 	var verify = func(req *http.Request) {}
 
-	api, srv := segmentsTrackServer(t, verify)
+	srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.AddPeopleToSegment(context.Background(), notFoundID, "id", customerIDs)
+	api := customerio.NewTrackClient("test", "myKey")
+	api.URL = srv.URL
+
+	err := api.AddPeopleToSegment(context.Background(), notFoundID, customerIDs)
 	if err == nil {
 		t.Errorf("Expected error, got: %#v", err)
 	}
@@ -114,7 +148,7 @@ func TestAddPeopleToSegmentError(t *testing.T) {
 	}
 }
 
-func segmentsTrackServer(t *testing.T, verify func(req *http.Request)) (*customerio.CustomerIO, *httptest.Server) {
+func segmentsTrackServer(t *testing.T, verify func(req *http.Request)) *httptest.Server {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		verify(req)
 
@@ -132,25 +166,20 @@ func segmentsTrackServer(t *testing.T, verify func(req *http.Request)) (*custome
 		}
 	}))
 
-	api := customerio.NewCustomerIO("test", "myKey")
-	api.URL = srv.URL
-
-	return api, srv
+	return srv
 }
 
 func TestRemovePeopleFromSegment(t *testing.T) {
 	customerIDs := []string{"1", "2", "3"}
-	var verify = func(req *http.Request) {
-		idType := req.URL.Query().Get("id_type")
-		if idType != "id" {
-			t.Errorf("Expected id_type to be 'id', got '%s'", idType)
-		}
-	}
+	var verify = func(req *http.Request) {}
 
-	api, srv := segmentsTrackServer(t, verify)
+	srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, "id", customerIDs)
+	api := customerio.NewTrackClient("test", "myKey")
+	api.URL = srv.URL
+
+	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, customerIDs)
 	if err != nil {
 		t.Error(err)
 	}
@@ -165,10 +194,13 @@ func TestRemovePeopleToSegmentEmailIDType(t *testing.T) {
 		}
 	}
 
-	api, srv := segmentsTrackServer(t, verify)
+	srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, "email", customerIDs)
+	api := customerio.NewTrackClient("test", "myKey", customerio.WithIDType("email"))
+	api.URL = srv.URL
+
+	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, customerIDs)
 	if err != nil {
 		t.Error(err)
 	}
@@ -183,10 +215,34 @@ func TestRemovePeopleToSegmentCioIDType(t *testing.T) {
 		}
 	}
 
-	api, srv := segmentsTrackServer(t, verify)
+	srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, "cio_id", customerIDs)
+	api := customerio.NewTrackClient("test", "myKey", customerio.WithIDType("cio_id"))
+	api.URL = srv.URL
+
+	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, customerIDs)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestRemovePeopleToSegmentInvalidIDType(t *testing.T) {
+	customerIDs := []string{"1", "2", "3"}
+	var verify = func(req *http.Request) {
+		idType := req.URL.Query().Get("id_type")
+		if idType != "id" {
+			t.Errorf("Expected id_type to be 'id', got '%s'", idType)
+		}
+	}
+
+	srv := segmentsTrackServer(t, verify)
+	defer srv.Close()
+
+	api := customerio.NewTrackClient("test", "myKey", customerio.WithIDType("invalid"))
+	api.URL = srv.URL
+
+	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, customerIDs)
 	if err != nil {
 		t.Error(err)
 	}
@@ -196,10 +252,13 @@ func TestRemovePeopleFromSegmentSegmentParamError(t *testing.T) {
 	var customerIDs []string
 	var verify = func(req *http.Request) {}
 
-	api, srv := segmentsTrackServer(t, verify)
+	srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.RemovePeopleFromSegment(context.Background(), 0, "id", customerIDs)
+	api := customerio.NewTrackClient("test", "myKey")
+	api.URL = srv.URL
+
+	err := api.RemovePeopleFromSegment(context.Background(), 0, customerIDs)
 	if err == nil {
 		t.Errorf("Expected error, got: %#v", err)
 	}
@@ -213,10 +272,13 @@ func TestRemovePeopleFromSegmentIDsParamError(t *testing.T) {
 	var customerIDs []string
 	var verify = func(req *http.Request) {}
 
-	api, srv := segmentsTrackServer(t, verify)
+	srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, "id", customerIDs)
+	api := customerio.NewTrackClient("test", "myKey")
+	api.URL = srv.URL
+
+	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, customerIDs)
 	if err == nil {
 		t.Errorf("Expected error, got: %#v", err)
 	}
@@ -230,10 +292,13 @@ func TestRemovePeopleFromSegmentError(t *testing.T) {
 	customerIDs := []string{"1", "2", "3"}
 	var verify = func(req *http.Request) {}
 
-	api, srv := segmentsTrackServer(t, verify)
+	srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.RemovePeopleFromSegment(context.Background(), notFoundID, "id", customerIDs)
+	api := customerio.NewTrackClient("test", "myKey")
+	api.URL = srv.URL
+
+	err := api.RemovePeopleFromSegment(context.Background(), notFoundID, customerIDs)
 	if err == nil {
 		t.Errorf("Expected error, got: %#v", err)
 	}

--- a/transactional.go
+++ b/transactional.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"time"
 )
@@ -29,7 +28,7 @@ func (c *APIClient) sendTransactional(ctx context.Context, typ TransactionalType
 		return nil, ErrInvalidTransactionalMessageType
 	}
 
-	body, statusCode, err := c.doRequest(ctx, "POST", fmt.Sprintf("/v1/send/%s", api), req)
+	body, statusCode, err := c.doRequest(ctx, "POST", req, "v1", "send", api)
 	if err != nil {
 		return nil, err
 	}

--- a/url.go
+++ b/url.go
@@ -1,0 +1,33 @@
+package customerio
+
+import (
+	"net/url"
+	"strings"
+)
+
+// buildURL joins the given path segments onto base and appends the optional
+// query parameters, returning a fully-formed URL string. Each segment is
+// percent-escaped, so dynamic values (customer IDs, device IDs) can be passed
+// without pre-escaping; a "/" inside a segment is encoded as %2F rather than
+// being treated as a path separator.
+func buildURL(base string, query url.Values, segments ...string) (string, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+
+	rawPath := strings.TrimRight(u.EscapedPath(), "/")
+	path := strings.TrimRight(u.Path, "/")
+	for _, s := range segments {
+		rawPath += "/" + url.PathEscape(s)
+		path += "/" + s
+	}
+	u.Path = path
+	u.RawPath = rawPath
+
+	if len(query) > 0 {
+		u.RawQuery = query.Encode()
+	}
+
+	return u.String(), nil
+}

--- a/url_test.go
+++ b/url_test.go
@@ -1,0 +1,67 @@
+package customerio
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestBuildURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     string
+		query    url.Values
+		segments []string
+		want     string
+	}{
+		{
+			name:     "no query",
+			base:     "https://track.customer.io",
+			segments: []string{"api", "v1", "events"},
+			want:     "https://track.customer.io/api/v1/events",
+		},
+		{
+			name:     "base with trailing slash",
+			base:     "https://track.customer.io/",
+			segments: []string{"api", "v1", "events"},
+			want:     "https://track.customer.io/api/v1/events",
+		},
+		{
+			name:     "nil query produces no query string",
+			base:     "https://track.customer.io",
+			query:    nil,
+			segments: []string{"api", "v1", "segments", "42", "add_customers"},
+			want:     "https://track.customer.io/api/v1/segments/42/add_customers",
+		},
+		{
+			name:     "with query",
+			base:     "https://track.customer.io",
+			query:    url.Values{"id_type": {"email"}},
+			segments: []string{"api", "v1", "segments", "42", "add_customers"},
+			want:     "https://track.customer.io/api/v1/segments/42/add_customers?id_type=email",
+		},
+		{
+			name:     "dynamic segment with special characters is escaped",
+			base:     "https://track.customer.io",
+			segments: []string{"api", "v1", "customers", "john doe"},
+			want:     "https://track.customer.io/api/v1/customers/john%20doe",
+		},
+		{
+			name:     "slash inside a segment is encoded as %2F",
+			base:     "https://track.customer.io",
+			segments: []string{"api", "v1", "customers", "abc/def"},
+			want:     "https://track.customer.io/api/v1/customers/abc%2Fdef",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildURL(tt.base, tt.query, tt.segments...)
+			if err != nil {
+				t.Fatalf("buildURL() unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("buildURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add buildURL helper using url.PathEscape + url.Values; replace
  fmt.Sprintf URL construction across track and API clients
  (customerio.go, device.go, segments_customerio.go, api.go,
  segments_api.go, transactional.go). api.go doRequest now takes
  variadic path segments. Behavior preserved (incl. %2F encoding of
  '/' inside IDs); JoinPath avoided. Adds url_test.go.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every outbound request URL is formed; incorrect escaping or path joining would break Track/App calls, though behavior is explicitly preserved and covered by `url_test.go` and httptest suites.
> 
> **Overview**
> Introduces a shared **`buildURL`** helper (`url.PathEscape`, optional query via `url.Values`) and routes Track and App API calls through it instead of **`fmt.Sprintf`** string URLs. **`APIClient.doRequest`** now accepts variadic path segments and only JSON-marshals the body when non-nil.
> 
> Track endpoints in **`customerio.go`**, **`device.go`**, and segment membership in **`segments_customerio.go`** use **`buildURL`**; App segment and transactional calls use the updated **`doRequest`**. **`WithIDType`** configures `id_type` on add/remove segment membership requests.
> 
> Adds App API segment CRUD/listing helpers (**`segments_api.go`**) and Track **`AddPeopleToSegment`** / **`RemovePeopleFromSegment`**, plus **`SEGMENTS.md`** and a README link. **`url_test.go`** locks in escaping (including `%2F` inside IDs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62df301713332bbf3fa8e4d01694adbe08d2f811. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->