### PR TITLE
refactor(customerio): centralize URL path building in a formatPath helper [AMPB-826]

### DIFF
--- a/customerio.go
+++ b/customerio.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 )
 
@@ -89,9 +88,7 @@ func (c *CustomerIO) IdentifyCtx(ctx context.Context, customerID string, attribu
 	if customerID == "" {
 		return ParamError{Param: "customerID"}
 	}
-	return c.request(ctx, "PUT",
-		fmt.Sprintf("%s/api/v1/customers/%s", c.URL, url.PathEscape(customerID)),
-		attributes)
+	return c.request(ctx, "PUT", c.URL+formatPath("/api/v1/customers/%s", customerID), attributes)
 }
 
 // Identify identifies a customer and sets their attributes
@@ -107,9 +104,7 @@ func (c *CustomerIO) TrackCtx(ctx context.Context, customerID string, eventName 
 	if eventName == "" {
 		return ParamError{Param: "eventName"}
 	}
-	return c.request(ctx, "POST",
-		fmt.Sprintf("%s/api/v1/customers/%s/events", c.URL, url.PathEscape(customerID)),
-		trackPayload(eventName, data, opts...))
+	return c.request(ctx, "POST", c.URL+formatPath("/api/v1/customers/%s/events", customerID), trackPayload(eventName, data, opts...))
 }
 
 // Track sends a single event to Customer.io for the supplied user
@@ -129,7 +124,7 @@ func (c *CustomerIO) TrackAnonymousCtx(ctx context.Context, anonymousID, eventNa
 		payload["anonymous_id"] = anonymousID
 	}
 
-	return c.request(ctx, "POST", fmt.Sprintf("%s/api/v1/events", c.URL), payload)
+	return c.request(ctx, "POST", c.URL+"/api/v1/events", payload)
 }
 
 // TrackAnonymous sends a single event to Customer.io for the anonymous user
@@ -142,9 +137,7 @@ func (c *CustomerIO) DeleteCtx(ctx context.Context, customerID string) error {
 	if customerID == "" {
 		return ParamError{Param: "customerID"}
 	}
-	return c.request(ctx, "DELETE",
-		fmt.Sprintf("%s/api/v1/customers/%s", c.URL, url.PathEscape(customerID)),
-		nil)
+	return c.request(ctx, "DELETE", c.URL+formatPath("/api/v1/customers/%s", customerID), nil)
 }
 
 func (c *CustomerIO) auth() string {
@@ -212,12 +205,10 @@ func (c *CustomerIO) MergeCustomersCtx(ctx context.Context, primary Identifier, 
 		return fmt.Errorf("secondary: %w", err)
 	}
 
-	return c.request(ctx, "POST",
-		fmt.Sprintf("%s/api/v1/merge_customers", c.URL),
-		map[string]any{
-			"primary":   primary.kv(),
-			"secondary": secondary.kv(),
-		})
+	return c.request(ctx, "POST", c.URL+"/api/v1/merge_customers", map[string]any{
+		"primary":   primary.kv(),
+		"secondary": secondary.kv(),
+	})
 }
 
 // MergeCustomers sends a request to Customer.io to merge two customer profiles together.

--- a/device.go
+++ b/device.go
@@ -3,7 +3,6 @@ package customerio
 import (
 	"context"
 	"fmt"
-	"net/url"
 )
 
 type deviceV1 struct {
@@ -82,9 +81,7 @@ func (c *CustomerIO) AddDeviceCtx(ctx context.Context, customerID string, device
 		"device": d,
 	}
 
-	return c.request(ctx, "PUT",
-		fmt.Sprintf("%s/api/v1/customers/%s/devices", c.URL, url.PathEscape(customerID)),
-		body)
+	return c.request(ctx, "PUT", c.URL+formatPath("/api/v1/customers/%s/devices", customerID), body)
 }
 
 // AddDevice adds a device for a customer
@@ -100,9 +97,7 @@ func (c *CustomerIO) DeleteDeviceCtx(ctx context.Context, customerID string, dev
 	if deviceID == "" {
 		return ParamError{Param: "deviceID"}
 	}
-	return c.request(ctx, "DELETE",
-		fmt.Sprintf("%s/api/v1/customers/%s/devices/%s", c.URL, url.PathEscape(customerID), url.PathEscape(deviceID)),
-		nil)
+	return c.request(ctx, "DELETE", c.URL+formatPath("/api/v1/customers/%s/devices/%s", customerID, deviceID), nil)
 }
 
 // DeleteDevice deletes a device for a customer

--- a/segments.go
+++ b/segments.go
@@ -2,7 +2,6 @@ package customerio
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 )
 
@@ -26,7 +25,7 @@ func (c *CustomerIO) segmentMembership(ctx context.Context, action string, segme
 		return ParamError{Param: "ids"}
 	}
 
-	u := fmt.Sprintf("%s/api/v1/segments/%d/%s", c.URL, segmentID, action)
+	u := c.URL + formatPath("/api/v1/segments/%d/%s", segmentID, action)
 
 	// url.Values handles encoding for any future option that carries an
 	// arbitrary string; current options (id_type) only emit URL-safe values.

--- a/transactional.go
+++ b/transactional.go
@@ -35,7 +35,7 @@ func (c *APIClient) sendTransactional(ctx context.Context, typ TransactionalType
 		return nil, ErrInvalidTransactionalMessageType
 	}
 
-	body, statusCode, err := c.doRequest(ctx, "POST", fmt.Sprintf("/v1/send/%s", api), req)
+	body, statusCode, err := c.doRequest(ctx, "POST", formatPath("/v1/send/%s", api), req)
 	if err != nil {
 		return nil, err
 	}

--- a/trigger_broadcast.go
+++ b/trigger_broadcast.go
@@ -3,7 +3,6 @@ package customerio
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 )
 
@@ -68,7 +67,7 @@ func (c *APIClient) TriggerBroadcast(ctx context.Context, broadcastID int, data 
 
 	payload := buildBroadcastPayload(broadcastInput{Data: data, Recipients: recipients, Options: opts})
 
-	requestPath := fmt.Sprintf("/v1/campaigns/%d/triggers", broadcastID)
+	requestPath := formatPath("/v1/campaigns/%d/triggers", broadcastID)
 	body, statusCode, err := c.doRequest(ctx, "POST", requestPath, payload)
 	if err != nil {
 		return nil, err

--- a/url.go
+++ b/url.go
@@ -1,0 +1,22 @@
+package customerio
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// formatPath builds a request path from a printf-style format string, escaping
+// any string argument with url.PathEscape so dynamic values (customer IDs,
+// device IDs) are safe to interpolate without pre-escaping; a "/" inside such a
+// value is encoded as %2F rather than being treated as a path separator.
+// Non-string arguments (e.g. integer IDs) are passed through unchanged.
+//
+// The returned path does not include the base URL; callers prepend it.
+func formatPath(format string, args ...any) string {
+	for i, a := range args {
+		if s, ok := a.(string); ok {
+			args[i] = url.PathEscape(s)
+		}
+	}
+	return fmt.Sprintf(format, args...)
+}

--- a/url_test.go
+++ b/url_test.go
@@ -1,0 +1,50 @@
+package customerio
+
+import "testing"
+
+func TestFormatPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		args   []any
+		want   string
+	}{
+		{
+			name:   "no args",
+			format: "/api/v1/events",
+			want:   "/api/v1/events",
+		},
+		{
+			name:   "string arg is escaped",
+			format: "/api/v1/customers/%s",
+			args:   []any{"john doe"},
+			want:   "/api/v1/customers/john%20doe",
+		},
+		{
+			name:   "slash inside a string arg is encoded as %2F",
+			format: "/api/v1/customers/%s",
+			args:   []any{"abc/def"},
+			want:   "/api/v1/customers/abc%2Fdef",
+		},
+		{
+			name:   "multiple string args",
+			format: "/api/v1/customers/%s/devices/%s",
+			args:   []any{"cust/1", "dev 2"},
+			want:   "/api/v1/customers/cust%2F1/devices/dev%202",
+		},
+		{
+			name:   "non-string arg passes through",
+			format: "/api/v1/segments/%d/%s",
+			args:   []any{42, "add_customers"},
+			want:   "/api/v1/segments/42/add_customers",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatPath(tt.format, tt.args...); got != tt.want {
+				t.Errorf("formatPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds `formatPath`, a small printf-style path builder that `url.PathEscape`s string arguments (so a `/` inside an ID becomes `%2F`) and passes non-string args (e.g. int IDs) through unchanged. Routes Track and App API path construction through it across `customerio.go`, `device.go`, `segments.go`, `transactional.go`, and `trigger_broadcast.go`. Behavior is preserved; adds `url_test.go`.

This is a rework of #73 on top of current main. 

`APIClient.doRequest` is unchanged from main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches URL construction for every outbound API call; regressions could mis-route requests, though behavior is intended to match prior escaping and is covered by new unit tests.
> 
> **Overview**
> Introduces **`formatPath`**, a shared helper that builds request paths from a `printf`-style template and automatically **`url.PathEscape`s string arguments** (including encoding `/` as `%2F`), while leaving non-string args (e.g. segment/broadcast IDs) unchanged.
> 
> Track and App API callers now build paths through **`formatPath`** instead of ad hoc **`fmt.Sprintf`** plus manual escaping: customer identify/track/delete, device add/delete, segment membership URLs, transactional send paths, and broadcast trigger paths. Static paths (e.g. anonymous events, merge customers) use simple string concatenation where there are no dynamic segments.
> 
> Adds **`url_test.go`** with cases for spaces, slashes in IDs, multiple string segments, and integer path segments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 045cbee0e4d61ed853fede1588cf3c49eeef0ecc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->