### PR TITLE
Add CC field to SendEmailRequest

### DIFF
--- a/send_email.go
+++ b/send_email.go
@@ -16,6 +16,7 @@ type SendEmailRequest struct {
 	From                    string            `json:"from,omitempty"`
 	To                      string            `json:"to,omitempty"`
 	ReplyTo                 string            `json:"reply_to,omitempty"`
+	CC                      string            `json:"cc,omitempty"`
 	BCC                     string            `json:"bcc,omitempty"`
 	Subject                 string            `json:"subject,omitempty"`
 	Preheader               string            `json:"preheader,omitempty"`


### PR DESCRIPTION
Adds support for the cc parameter in transactional email requests by introducing a new CC field on SendEmailRequest. 

Reference:
https://docs.customer.io/integrations/api/app/#tag/send-messages/POST/v1/send/email.body.cc
<img width="1505" height="1046" alt="image" src="https://github.com/user-attachments/assets/84d2e82d-4596-417e-91f8-60bd3ea50a4f" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single optional struct field with no custom validation or send-path changes; behavior matches existing recipient fields.
> 
> **Overview**
> Adds optional **CC** support on transactional email sends by extending `SendEmailRequest` with a `CC` field serialized as `cc` in the API payload, aligned with Customer.io’s send-email API (same pattern as existing `To`, `ReplyTo`, and `BCC`).
> 
> No other code paths change; `SendEmail` continues to pass the request through the transactional sender, so callers can set carbon-copy recipients when building the request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c114a25e3a5fb7251efb996ec3bd5475ff40901f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->