### PR TITLE
Add `SendWhatsApp` transactional method

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,36 @@ if err != nil {
 fmt.Println(body)
 ```
 
+## WhatsApp
+Create a `customerio.SendWhatsAppRequest` instance, and then use `(c *customerio.APIClient).SendWhatsApp` to send your message. [Learn more about transactional messages and optional `SendWhatsApp` properties](https://customer.io/docs/transactional-api).
+
+```go
+client := customerio.NewAPIClient("<extapikey>", customerio.WithRegion(customerio.RegionUS));
+
+// To   — the WhatsApp number (E.164) of your recipient.
+// From — the WhatsApp number (E.164) you're sending from. Optional if the
+//        referenced transactional_message_id already defines it.
+
+request := customerio.SendWhatsAppRequest{
+  TransactionalMessageID: "3",
+  To:   "+15551234567",
+  From: "+15559876543",
+  MessageData: map[string]any{
+    "name": "Person",
+  },
+  Identifiers: map[string]string{
+    "id": "example1",
+  },
+}
+
+body, err := client.SendWhatsApp(context.Background(), &request)
+if err != nil {
+  // handle error
+}
+
+fmt.Println(body)
+```
+
 ## Triggering API Broadcasts
 
 Use `(c *customerio.APIClient).TriggerBroadcast` to trigger a broadcast campaign. [Learn more about triggering a broadcast here](https://docs.customer.io/journeys/api-triggered-broadcasts/) via the App API.

--- a/send_whatsapp.go
+++ b/send_whatsapp.go
@@ -1,0 +1,36 @@
+package customerio
+
+import (
+	"context"
+)
+
+type SendWhatsAppRequest struct {
+	MessageData             map[string]any    `json:"message_data,omitempty"`
+	TransactionalMessageID  string            `json:"transactional_message_id,omitempty"`
+	Identifiers             map[string]string `json:"identifiers"`
+	DisableMessageRetention *bool             `json:"disable_message_retention,omitempty"`
+	SendToUnsubscribed      *bool             `json:"send_to_unsubscribed,omitempty"`
+	QueueDraft              *bool             `json:"queue_draft,omitempty"`
+	SendAt                  *int64            `json:"send_at,omitempty"`
+	Language                *string           `json:"language,omitempty"`
+
+	From    string `json:"from,omitempty"`
+	To      string `json:"to,omitempty"`
+	Tracked *bool  `json:"tracked,omitempty"`
+}
+
+type SendWhatsAppResponse struct {
+	TransactionalResponse
+}
+
+// SendWhatsApp sends a single transactional WhatsApp message using the Customer.io transactional API
+func (c *APIClient) SendWhatsApp(ctx context.Context, req *SendWhatsAppRequest) (*SendWhatsAppResponse, error) {
+	resp, err := c.sendTransactional(ctx, TransactionalTypeWhatsApp, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SendWhatsAppResponse{
+		*resp,
+	}, nil
+}

--- a/send_whatsapp_test.go
+++ b/send_whatsapp_test.go
@@ -1,0 +1,84 @@
+package customerio_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/customerio/go-customerio/v3"
+)
+
+func TestSendWhatsApp(t *testing.T) {
+	req := &customerio.SendWhatsAppRequest{
+		TransactionalMessageID: "123456",
+		Identifiers: map[string]string{
+			"id": "customer_1",
+		},
+		To:      "+12345678900",
+		From:    "+18007654321",
+		Tracked: &[]bool{true}[0],
+		MessageData: map[string]any{
+			"token": "123456",
+		},
+		DisableMessageRetention: &[]bool{true}[0],
+	}
+
+	var verify = func(request []byte) {
+		var body customerio.SendWhatsAppRequest
+		if err := json.Unmarshal(request, &body); err != nil {
+			t.Error(err)
+		}
+
+		if !reflect.DeepEqual(&body, req) {
+			t.Errorf("Request differed, want: %#v, got: %#v", request, body)
+		}
+	}
+
+	api, srv := transactionalServer(t, verify)
+	defer srv.Close()
+
+	resp, err := api.SendWhatsApp(context.Background(), req)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expect := &customerio.SendWhatsAppResponse{
+		TransactionalResponse: customerio.TransactionalResponse{
+			DeliveryID: testDeliveryID,
+			QueuedAt:   time.Unix(int64(testQueuedAt), 0),
+		},
+	}
+
+	if !reflect.DeepEqual(resp, expect) {
+		t.Errorf("Expect: %#v, Got: %#v", expect, resp)
+	}
+}
+
+func TestSendWhatsAppError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(502)
+	}))
+	defer srv.Close()
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+
+	resp, err := api.SendWhatsApp(context.Background(), &customerio.SendWhatsAppRequest{
+		TransactionalMessageID: "123456",
+		Identifiers: map[string]string{
+			"id": "customer_1",
+		},
+		To: "+12345678900",
+	})
+	if err == nil {
+		t.Errorf("Expected error, got: %#v", resp)
+	}
+
+	if _, ok := err.(*customerio.TransactionalError); !ok {
+		t.Errorf("Expected TransactionalError, got: %#v", err)
+	}
+}

--- a/transactional.go
+++ b/transactional.go
@@ -17,6 +17,7 @@ const (
 	TransactionalTypeSMS          TransactionalType = 2
 	TransactionalTypeInboxMessage TransactionalType = 3
 	TransactionalTypeInApp        TransactionalType = 4
+	TransactionalTypeWhatsApp     TransactionalType = 5
 )
 
 var typeToApi = map[TransactionalType]string{
@@ -25,6 +26,7 @@ var typeToApi = map[TransactionalType]string{
 	TransactionalTypeSMS:          "sms",
 	TransactionalTypeInboxMessage: "inbox_message",
 	TransactionalTypeInApp:        "in_app",
+	TransactionalTypeWhatsApp:     "whatsapp",
 }
 
 var ErrInvalidTransactionalMessageType = errors.New("unknown transactional message type")


### PR DESCRIPTION
## Summary

The backend serves `POST /v1/send/whatsapp`, but the SDK didn't expose it. Adds a `SendWhatsApp` method mirroring the existing `SendSMS` surface.

## Changes

- `SendWhatsAppRequest` / `SendWhatsAppResponse` + `APIClient.SendWhatsApp` in `send_whatsapp.go` — mirrors `send_sms.go`, with `From`/`To` (E.164) plus the `Tracked` flag the handler reads.
- New `TransactionalTypeWhatsApp` + `typeToApi` entry → `POST /v1/send/whatsapp`.
- Round-trip and error tests in `send_whatsapp_test.go`.
- README "WhatsApp" section.
