### PR TITLE
Add App API transactional message management and cross-resource Messages

### DIFF
--- a/activities.go
+++ b/activities.go
@@ -1,0 +1,58 @@
+package customerio
+
+import "context"
+
+// Activity is an entry from GET /activities or GET /customers/{id}/activities.
+// Data's shape varies by Type: message-delivery activities (sent_email,
+// delivered_email, opened_email, ...) carry {delivery_id, delivered, opened};
+// attribute_change activities carry a map of attribute name to {from, to};
+// event/page/screen activities have no documented shape. It is left as
+// map[string]any rather than modeled per Type for that reason.
+type Activity struct {
+	ID                  string               `json:"id"`
+	Type                string               `json:"type"`
+	Timestamp           int64                `json:"timestamp"`
+	CustomerID          string               `json:"customer_id,omitempty"`
+	CustomerIdentifiers *CustomerIdentifiers `json:"customer_identifiers,omitempty"`
+	DeliveryID          string               `json:"delivery_id,omitempty"`
+	DeliveryType        string               `json:"delivery_type,omitempty"`
+	Name                string               `json:"name,omitempty"`
+	URL                 string               `json:"url,omitempty"`
+	Data                map[string]any       `json:"data,omitempty"`
+}
+
+// ActivitiesResponse is the decoded shape of GET /activities and
+// GET /customers/{id}/activities.
+type ActivitiesResponse struct {
+	Activities []Activity `json:"activities"`
+	Next       string     `json:"next,omitempty"`
+}
+
+// ListActivitiesOptions filters ListActivities.
+type ListActivitiesOptions struct {
+	PaginationOptions
+	Type       string
+	Name       string
+	Deleted    *bool
+	CustomerID string
+	IDType     IdentifierType
+}
+
+// ListActivities returns activity records across all customers, most recent
+// first. See https://docs.customer.io/api/app/#operation/listActivities
+func (c *APIClient) ListActivities(ctx context.Context, opts ListActivitiesOptions) (*ActivitiesResponse, error) {
+	q := opts.PaginationOptions.apply(newQuery()).
+		setString("type", opts.Type).
+		setString("name", opts.Name).
+		setBool("deleted", opts.Deleted).
+		setString("customer_id", opts.CustomerID).
+		setString("id_type", string(opts.IDType))
+
+	requestPath := "/v1/activities" + q.String()
+
+	var resp ActivitiesResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/activities_test.go
+++ b/activities_test.go
@@ -1,0 +1,40 @@
+package customerio_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/customerio/go-customerio/v3"
+)
+
+func TestListActivities(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"activities": []map[string]any{
+		{"id": "act1", "type": "event", "timestamp": 1700000000, "name": "purchased"},
+	}, "next": "cursor2"})
+
+	deleted := false
+	got, err := api.ListActivities(context.Background(), customerio.ListActivitiesOptions{
+		Type:              "event",
+		Name:              "purchased",
+		Deleted:           &deleted,
+		CustomerID:        "1",
+		IDType:            customerio.IdentifierTypeID,
+		PaginationOptions: customerio.PaginationOptions{Limit: 25},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/activities?customer_id=1&deleted=false&id_type=id&limit=25&name=purchased&type=event")
+	if len(got.Activities) != 1 || got.Activities[0].Name != "purchased" || got.Next != "cursor2" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestListActivitiesNoOptions(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"activities": []any{}})
+
+	if _, err := api.ListActivities(context.Background(), customerio.ListActivitiesOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/activities")
+}

--- a/api.go
+++ b/api.go
@@ -2,6 +2,7 @@ package customerio
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 )
 
@@ -42,4 +43,37 @@ func (c *APIClient) doRequest(ctx context.Context, verb, requestPath string, bod
 	return doHTTP(ctx, c.Client, verb, c.URL+requestPath, c.UserAgent, body, func(req *http.Request) {
 		req.Header.Set("Authorization", "Bearer "+c.Key)
 	})
+}
+
+// doJSON executes verb against requestPath, marshaling body as the JSON
+// request payload (nil for none) and unmarshaling the response into out
+// (nil to discard it). A response whose status isn't in okStatuses
+// (defaulting to just http.StatusOK) is returned as a *CustomerIOError.
+func (c *APIClient) doJSON(ctx context.Context, verb, requestPath string, body, out any, okStatuses ...int) error {
+	if len(okStatuses) == 0 {
+		okStatuses = []int{http.StatusOK}
+	}
+
+	respBody, statusCode, err := c.doRequest(ctx, verb, requestPath, body)
+	if err != nil {
+		return err
+	}
+
+	ok := false
+	for _, s := range okStatuses {
+		if statusCode == s {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return &CustomerIOError{status: statusCode, url: c.URL + requestPath, body: respBody}
+	}
+
+	if out != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, out); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/api_helpers_test.go
+++ b/api_helpers_test.go
@@ -1,0 +1,89 @@
+package customerio_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/customerio/go-customerio/v3"
+)
+
+// apiRecord captures the most recent request made through an apiServer.
+type apiRecord struct {
+	method string
+	path   string
+	body   map[string]any
+}
+
+// apiServer creates a per-test HTTP server and APIClient for App API tests.
+// Every request gets statusCode and responseBody (JSON-encoded); the
+// request actually sent is captured into the returned apiRecord so tests
+// can assert against it afterwards.
+func apiServer(t *testing.T, statusCode int, responseBody any) (*customerio.APIClient, *apiRecord) {
+	t.Helper()
+	rec := &apiRecord{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		b, err := io.ReadAll(req.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer func() { _ = req.Body.Close() }()
+
+		rec.method = req.Method
+		rec.path = req.RequestURI
+		rec.body = nil
+		if len(b) > 0 {
+			dec := json.NewDecoder(bytes.NewReader(b))
+			dec.UseNumber()
+			if err := dec.Decode(&rec.body); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
+		w.WriteHeader(statusCode)
+		if responseBody != nil {
+			// errcheck (golangci-lint): explicitly discard return values
+			_ = json.NewEncoder(w).Encode(responseBody)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+	return api, rec
+}
+
+func assertAPIRequest(t *testing.T, rec *apiRecord, method, path string) {
+	t.Helper()
+	if rec.method != method {
+		t.Errorf("expected method %s got %s", method, rec.method)
+	}
+	if rec.path != path {
+		t.Errorf("expected path %s got %s", path, rec.path)
+	}
+}
+
+// assertJSONEqual compares got and want by marshaling both to JSON, rather
+// than reflect.DeepEqual — apiServer decodes request bodies with UseNumber,
+// so a captured numeric field is a json.Number, which never DeepEqual's a
+// float64 literal in a hand-written expectation even when both serialize
+// identically.
+func assertJSONEqual(t *testing.T, got, want any) {
+	t.Helper()
+	gotJSON, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantJSON, err := json.Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(gotJSON, wantJSON) {
+		t.Errorf("body mismatch\nexpected: %s\ngot:      %s", wantJSON, gotJSON)
+	}
+}

--- a/app_segments.go
+++ b/app_segments.go
@@ -1,0 +1,164 @@
+package customerio
+
+import (
+	"context"
+	"net/http"
+)
+
+// Segment is a manual or data-driven audience segment.
+type Segment struct {
+	ID            int      `json:"id"`
+	DeduplicateID string   `json:"deduplicate_id,omitempty"`
+	Name          string   `json:"name"`
+	Description   string   `json:"description,omitempty"`
+	State         string   `json:"state,omitempty"`
+	Progress      *int     `json:"progress,omitempty"`
+	Type          string   `json:"type,omitempty"`
+	Tags          []string `json:"tags,omitempty"`
+	CreatedAt     int64    `json:"created_at,omitempty"`
+	UpdatedAt     int64    `json:"updated_at,omitempty"`
+}
+
+// SegmentResponse wraps a single Segment, as returned by CreateSegment and GetSegment.
+type SegmentResponse struct {
+	Segment Segment `json:"segment"`
+}
+
+// ListSegmentsResponse is the decoded shape of GET /v1/segments.
+type ListSegmentsResponse struct {
+	Segments []Segment `json:"segments"`
+}
+
+// ListSegments returns every segment defined in the workspace.
+// See https://docs.customer.io/api/app/#operation/listSegments
+func (c *APIClient) ListSegments(ctx context.Context) (*ListSegmentsResponse, error) {
+	var resp ListSegmentsResponse
+	if err := c.doJSON(ctx, "GET", "/v1/segments", nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// SegmentInput describes a new manual segment.
+type SegmentInput struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+type createSegmentRequest struct {
+	Segment SegmentInput `json:"segment"`
+}
+
+// CreateSegment creates a new manual segment.
+// See https://docs.customer.io/api/app/#operation/createSegment
+func (c *APIClient) CreateSegment(ctx context.Context, input SegmentInput) (*SegmentResponse, error) {
+	if input.Name == "" {
+		return nil, ParamError{Param: "name"}
+	}
+
+	var resp SegmentResponse
+	if err := c.doJSON(ctx, "POST", "/v1/segments", createSegmentRequest{Segment: input}, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetSegment returns one segment by id.
+// See https://docs.customer.io/api/app/#operation/getSegment
+func (c *APIClient) GetSegment(ctx context.Context, segmentID int) (*SegmentResponse, error) {
+	if segmentID <= 0 {
+		return nil, ParamError{Param: "segmentID"}
+	}
+
+	var resp SegmentResponse
+	if err := c.doJSON(ctx, "GET", formatPath("/v1/segments/%d", segmentID), nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// DeleteSegment deletes a manual segment by id.
+// See https://docs.customer.io/api/app/#operation/deleteSegment
+func (c *APIClient) DeleteSegment(ctx context.Context, segmentID int) error {
+	if segmentID <= 0 {
+		return ParamError{Param: "segmentID"}
+	}
+
+	return c.doJSON(ctx, "DELETE", formatPath("/v1/segments/%d", segmentID), nil, nil, http.StatusOK, http.StatusNoContent)
+}
+
+// SegmentCustomerCountResponse is the decoded shape of
+// GET /v1/segments/{id}/customer_count.
+type SegmentCustomerCountResponse struct {
+	SegmentID int `json:"segment_id"`
+	Count     int `json:"count"`
+}
+
+// GetSegmentCustomerCount returns how many customers currently belong to a segment.
+// See https://docs.customer.io/api/app/#operation/getSegmentCustomerCount
+func (c *APIClient) GetSegmentCustomerCount(ctx context.Context, segmentID int) (*SegmentCustomerCountResponse, error) {
+	if segmentID <= 0 {
+		return nil, ParamError{Param: "segmentID"}
+	}
+
+	var resp SegmentCustomerCountResponse
+	if err := c.doJSON(ctx, "GET", formatPath("/v1/segments/%d/customer_count", segmentID), nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// SegmentMembershipResponse is the decoded shape of
+// GET /v1/segments/{id}/membership. Which of IDs/Identifiers is populated
+// (and which CustomerIdentifiers fields are set) depends on the workspace's
+// identifier configuration.
+type SegmentMembershipResponse struct {
+	SegmentID   int                   `json:"segment_id"`
+	IDs         []string              `json:"ids,omitempty"`
+	Identifiers []CustomerIdentifiers `json:"identifiers,omitempty"`
+	Next        string                `json:"next,omitempty"`
+}
+
+// GetSegmentMembership returns the customers belonging to a segment.
+// See https://docs.customer.io/api/app/#operation/getSegmentMembership
+func (c *APIClient) GetSegmentMembership(ctx context.Context, segmentID int, opts PaginationOptions) (*SegmentMembershipResponse, error) {
+	if segmentID <= 0 {
+		return nil, ParamError{Param: "segmentID"}
+	}
+
+	requestPath := formatPath("/v1/segments/%d/membership", segmentID) + opts.apply(newQuery()).String()
+
+	var resp SegmentMembershipResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// SegmentUsedBy lists the campaigns/newsletters referencing a segment.
+type SegmentUsedBy struct {
+	Campaigns        []int `json:"campaigns,omitempty"`
+	SentNewsletters  []int `json:"sent_newsletters,omitempty"`
+	DraftNewsletters []int `json:"draft_newsletters,omitempty"`
+}
+
+// SegmentUsedByResponse is the decoded shape of GET /v1/segments/{id}/used_by.
+type SegmentUsedByResponse struct {
+	SegmentID int           `json:"segment_id"`
+	UsedBy    SegmentUsedBy `json:"used_by"`
+}
+
+// GetSegmentUsedBy returns what campaigns/newsletters reference a segment —
+// useful to check before deleting it.
+// See https://docs.customer.io/api/app/#operation/getSegmentUsedBy
+func (c *APIClient) GetSegmentUsedBy(ctx context.Context, segmentID int) (*SegmentUsedByResponse, error) {
+	if segmentID <= 0 {
+		return nil, ParamError{Param: "segmentID"}
+	}
+
+	var resp SegmentUsedByResponse
+	if err := c.doJSON(ctx, "GET", formatPath("/v1/segments/%d/used_by", segmentID), nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/app_segments_test.go
+++ b/app_segments_test.go
@@ -1,0 +1,134 @@
+package customerio_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/customerio/go-customerio/v3"
+)
+
+func TestListSegmentsApp(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"segments": []map[string]any{
+		{"id": 1, "name": "VIP", "type": "manual"},
+	}})
+	got, err := api.ListSegments(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/segments")
+	if len(got.Segments) != 1 || got.Segments[0].Name != "VIP" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestCreateSegment(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.CreateSegment(context.Background(), customerio.SegmentInput{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "name")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"segment": map[string]any{"id": 9, "name": "New"}})
+	got, err := api.CreateSegment(context.Background(), customerio.SegmentInput{Name: "New", Description: "desc"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "POST", "/v1/segments")
+	wantBody := map[string]any{"segment": map[string]any{"name": "New", "description": "desc"}}
+	assertJSONEqual(t, rec.body, wantBody)
+	if got.Segment.ID != 9 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetSegmentApp(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetSegment(context.Background(), 0); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "segmentID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"segment": map[string]any{"id": 7, "name": "Gold"}})
+	got, err := api.GetSegment(context.Background(), 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/segments/7")
+	if got.Segment.Name != "Gold" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestDeleteSegment(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if err := api.DeleteSegment(context.Background(), -1); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "segmentID")
+	}
+
+	api, rec := apiServer(t, 204, nil)
+	if err := api.DeleteSegment(context.Background(), 7); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "DELETE", "/v1/segments/7")
+}
+
+func TestGetSegmentCustomerCount(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"segment_id": 7, "count": 42})
+	got, err := api.GetSegmentCustomerCount(context.Background(), 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/segments/7/customer_count")
+	if got.Count != 42 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetSegmentMembership(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{
+		"segment_id":  7,
+		"ids":         []string{"1", "2"},
+		"identifiers": []map[string]any{{"id": "1"}, {"id": "2"}},
+		"next":        "cursor",
+	})
+	got, err := api.GetSegmentMembership(context.Background(), 7, customerio.PaginationOptions{Limit: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/segments/7/membership?limit=2")
+	if len(got.IDs) != 2 || got.Next != "cursor" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetSegmentUsedBy(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{
+		"segment_id": 7,
+		"used_by":    map[string]any{"campaigns": []int{1, 2}, "sent_newsletters": []int{3}},
+	})
+	got, err := api.GetSegmentUsedBy(context.Background(), 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/segments/7/used_by")
+	if len(got.UsedBy.Campaigns) != 2 || len(got.UsedBy.SentNewsletters) != 1 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestAppSegmentsError(t *testing.T) {
+	api, _ := apiServer(t, 404, map[string]any{"errors": []map[string]any{{"detail": "not found"}}})
+
+	_, err := api.GetSegment(context.Background(), 1)
+	cioErr, ok := err.(*customerio.CustomerIOError)
+	if !ok {
+		t.Fatalf("expected *CustomerIOError, got %T", err)
+	}
+	if cioErr.StatusCode() != 404 {
+		t.Errorf("expected status 404, got %d", cioErr.StatusCode())
+	}
+}

--- a/customers.go
+++ b/customers.go
@@ -1,0 +1,379 @@
+package customerio
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// CustomerIdentifiers identifies a customer by all three identifier kinds
+// Customer.io tracks. It appears in search/list results so callers can look
+// the customer up by whichever identifier they have on hand.
+type CustomerIdentifiers struct {
+	ID    string `json:"id,omitempty"`
+	Email string `json:"email,omitempty"`
+	CioID string `json:"cio_id,omitempty"`
+}
+
+// searchCustomersRequest is the POST /v1/customers body.
+type searchCustomersRequest struct {
+	Filter AudienceFilter `json:"filter"`
+}
+
+// SearchCustomersResponse is the decoded shape of POST /v1/customers.
+type SearchCustomersResponse struct {
+	Identifiers []CustomerIdentifiers `json:"identifiers"`
+	IDs         []string              `json:"ids"`
+	Next        string                `json:"next,omitempty"`
+}
+
+// SearchCustomers finds customers matching filter (built with FilterBySegment,
+// FilterByAttribute, and the FilterAnd/FilterOr/FilterNot combinators).
+// See https://docs.customer.io/api/app/#operation/searchCustomers
+func (c *APIClient) SearchCustomers(ctx context.Context, filter AudienceFilter, opts PaginationOptions) (*SearchCustomersResponse, error) {
+	requestPath := "/v1/customers" + opts.apply(newQuery()).String()
+
+	var resp SearchCustomersResponse
+	if err := c.doJSON(ctx, "POST", requestPath, searchCustomersRequest{Filter: filter}, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetCustomersByEmailResponse is the decoded shape of GET /v1/customers?email=.
+type GetCustomersByEmailResponse struct {
+	Results []CustomerIdentifiers `json:"results"`
+}
+
+// GetCustomersByEmail looks up every customer profile with the given email —
+// Customer.io allows duplicate emails across profiles, so this can return
+// more than one result. See https://docs.customer.io/api/app/#operation/getCustomersByEmail
+func (c *APIClient) GetCustomersByEmail(ctx context.Context, email string) (*GetCustomersByEmailResponse, error) {
+	if email == "" {
+		return nil, ParamError{Param: "email"}
+	}
+
+	requestPath := "/v1/customers" + newQuery().setString("email", email).String()
+
+	var resp GetCustomersByEmailResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// CustomerDevice is a push notification device registered to a customer.
+type CustomerDevice struct {
+	ID         string         `json:"id"`
+	LastUsed   int64          `json:"last_used,omitempty"`
+	Platform   string         `json:"platform"`
+	Attributes map[string]any `json:"attributes,omitempty"`
+}
+
+// Customer is a customer profile as returned by the attributes endpoints.
+// Attributes values are always strings on the wire.
+type Customer struct {
+	ID           string               `json:"id"`
+	Identifiers  *CustomerIdentifiers `json:"identifiers,omitempty"`
+	Attributes   map[string]string    `json:"attributes"`
+	Unsubscribed bool                 `json:"unsubscribed"`
+	Devices      []CustomerDevice     `json:"devices,omitempty"`
+}
+
+// CustomerAttributesResponse is the decoded shape of GET /v1/customers/{id}/attributes.
+type CustomerAttributesResponse struct {
+	Customer Customer `json:"customer"`
+}
+
+// GetAttributes returns a customer's profile attributes. idType selects
+// which kind of identifier id is; the zero value defaults to IdentifierTypeID.
+// See https://docs.customer.io/api/app/#operation/getPersonAttributes
+func (c *APIClient) GetAttributes(ctx context.Context, id string, idType IdentifierType) (*CustomerAttributesResponse, error) {
+	if id == "" {
+		return nil, ParamError{Param: "id"}
+	}
+	if idType == "" {
+		idType = IdentifierTypeID
+	}
+
+	requestPath := formatPath("/v1/customers/%s/attributes", id) + newQuery().setString("id_type", string(idType)).String()
+
+	var resp CustomerAttributesResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// CustomerActivitiesOptions filters GetCustomerActivities.
+type CustomerActivitiesOptions struct {
+	PaginationOptions
+	IDType IdentifierType
+	Type   string
+	Name   string
+}
+
+// GetCustomerActivities returns activity records (sends, opens, clicks,
+// events, attribute changes, ...) for one customer, most recent first.
+// See https://docs.customer.io/api/app/#operation/getPersonActivities
+func (c *APIClient) GetCustomerActivities(ctx context.Context, customerID string, opts CustomerActivitiesOptions) (*ActivitiesResponse, error) {
+	if customerID == "" {
+		return nil, ParamError{Param: "customerID"}
+	}
+
+	q := opts.PaginationOptions.apply(newQuery()).
+		setString("id_type", string(opts.IDType)).
+		setString("type", opts.Type).
+		setString("name", opts.Name)
+
+	requestPath := formatPath("/v1/customers/%s/activities", customerID) + q.String()
+
+	var resp ActivitiesResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// Message is an entry from GET /v1/customers/{id}/messages — a sent
+// email/push/SMS/etc. and its delivery metadata. Open/click/bounce state is
+// not part of this object; join against GetCustomerActivities (or
+// GetMessage's associations) for delivery lifecycle events.
+type Message struct {
+	ID             string           `json:"id"`
+	DeduplicateID  string           `json:"deduplicate_id,omitempty"`
+	CustomerID     string           `json:"customer_id,omitempty"`
+	CampaignID     int              `json:"campaign_id,omitempty"`
+	ActionID       int              `json:"action_id,omitempty"`
+	Recipient      string           `json:"recipient,omitempty"`
+	Subject        string           `json:"subject,omitempty"`
+	Metrics        map[string]int64 `json:"metrics,omitempty"`
+	Created        int64            `json:"created,omitempty"`
+	FailureMessage string           `json:"failure_message,omitempty"`
+	NewsletterID   *int             `json:"newsletter_id,omitempty"`
+	ContentID      *int             `json:"content_id,omitempty"`
+	BroadcastID    *int             `json:"broadcast_id,omitempty"`
+	Type           string           `json:"type,omitempty"`
+	Forgotten      bool             `json:"forgotten,omitempty"`
+}
+
+// MessagesResponse is the decoded shape of GET /v1/customers/{id}/messages.
+type MessagesResponse struct {
+	Messages []Message `json:"messages"`
+	Next     string    `json:"next,omitempty"`
+}
+
+// CustomerMessagesOptions filters GetCustomerMessages. IDType lets callers
+// look a customer up by email or cio_id directly (id_type=email skips a
+// separate SearchCustomers/GetCustomersByEmail round trip).
+type CustomerMessagesOptions struct {
+	PaginationOptions
+	IDType  IdentifierType
+	StartTS int64
+	EndTS   int64
+}
+
+// GetCustomerMessages returns messages sent to one customer, most recent
+// first. customerID is interpreted according to opts.IDType (default
+// IdentifierTypeID) — pass an email address with IDType: IdentifierTypeEmail
+// to look a customer up by email directly.
+// See https://docs.customer.io/api/app/#operation/getPersonMessages
+func (c *APIClient) GetCustomerMessages(ctx context.Context, customerID string, opts CustomerMessagesOptions) (*MessagesResponse, error) {
+	if customerID == "" {
+		return nil, ParamError{Param: "customerID"}
+	}
+
+	q := opts.PaginationOptions.apply(newQuery()).
+		setString("id_type", string(opts.IDType)).
+		setInt64("start_ts", opts.StartTS).
+		setInt64("end_ts", opts.EndTS)
+
+	requestPath := formatPath("/v1/customers/%s/messages", customerID) + q.String()
+
+	var resp MessagesResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// ObjectIdentifiers identifies an object by the two identifier kinds
+// Customer.io tracks for objects (as opposed to CustomerIdentifiers, which
+// is for customers).
+type ObjectIdentifiers struct {
+	ObjectID    string `json:"object_id,omitempty"`
+	CioObjectID string `json:"cio_object_id,omitempty"`
+}
+
+// CustomerRelationship is a customer's relationship to an object.
+// ObjectTypeID is decoded leniently (json.Number): the schema types it as
+// an integer, but the analogous GetObjectRelationships example shows it as
+// a numeric string.
+type CustomerRelationship struct {
+	ObjectTypeID json.Number       `json:"object_type_id,omitempty"`
+	Identifiers  ObjectIdentifiers `json:"identifiers"`
+	Attributes   map[string]any    `json:"attributes,omitempty"`
+	Timestamps   map[string]int64  `json:"timestamps,omitempty"`
+}
+
+// RelationshipsResponse is the decoded shape of GET /v1/customers/{id}/relationships.
+type RelationshipsResponse struct {
+	Relationships []CustomerRelationship `json:"cio_relationships"`
+	Next          string                 `json:"next,omitempty"`
+}
+
+// GetCustomerRelationships returns the objects a customer is related to.
+// See https://docs.customer.io/api/app/#operation/getPersonRelationships
+func (c *APIClient) GetCustomerRelationships(ctx context.Context, customerID string, opts PaginationOptions) (*RelationshipsResponse, error) {
+	if customerID == "" {
+		return nil, ParamError{Param: "customerID"}
+	}
+
+	requestPath := formatPath("/v1/customers/%s/relationships", customerID) + opts.apply(newQuery()).String()
+
+	var resp RelationshipsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// CustomerSegment is a manual or data-driven segment a customer belongs to.
+type CustomerSegment struct {
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// CustomerSegmentsResponse is the decoded shape of GET /v1/customers/{id}/segments.
+type CustomerSegmentsResponse struct {
+	Segments []CustomerSegment `json:"segments"`
+}
+
+// GetCustomerSegments returns the segments a customer belongs to. idType
+// selects which kind of identifier customerID is; the zero value defaults
+// to IdentifierTypeID. See https://docs.customer.io/api/app/#operation/getPersonSegments
+func (c *APIClient) GetCustomerSegments(ctx context.Context, customerID string, idType IdentifierType) (*CustomerSegmentsResponse, error) {
+	if customerID == "" {
+		return nil, ParamError{Param: "customerID"}
+	}
+	if idType == "" {
+		idType = IdentifierTypeID
+	}
+
+	requestPath := formatPath("/v1/customers/%s/segments", customerID) + newQuery().setString("id_type", string(idType)).String()
+
+	var resp CustomerSegmentsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// SubscriptionTopicPreference is one topic's subscription state for a
+// customer. ID is decoded leniently: the documented schema types it as a
+// string, but example responses show a JSON integer.
+type SubscriptionTopicPreference struct {
+	ID          json.Number `json:"id"`
+	Subscribed  bool        `json:"subscribed"`
+	Name        string      `json:"name,omitempty"`
+	Description string      `json:"description,omitempty"`
+}
+
+// SubscriptionPreferencesHeader is optional branding shown on the hosted
+// subscription preferences page.
+type SubscriptionPreferencesHeader struct {
+	Title    string `json:"title,omitempty"`
+	Subtitle string `json:"subtitle,omitempty"`
+}
+
+// SubscriptionPreferencesCustomer is the customer object returned by
+// GetCustomerSubscriptionPreferences.
+type SubscriptionPreferencesCustomer struct {
+	ID           string                         `json:"id"`
+	Identifiers  *CustomerIdentifiers           `json:"identifiers,omitempty"`
+	Topics       []SubscriptionTopicPreference  `json:"topics,omitempty"`
+	Unsubscribed bool                           `json:"unsubscribed"`
+	Header       *SubscriptionPreferencesHeader `json:"header,omitempty"`
+}
+
+// SubscriptionPreferencesResponse is the decoded shape of
+// GET /v1/customers/{id}/subscription_preferences.
+type SubscriptionPreferencesResponse struct {
+	Customer SubscriptionPreferencesCustomer `json:"customer"`
+}
+
+// CustomerSubscriptionPreferencesOptions configures GetCustomerSubscriptionPreferences.
+type CustomerSubscriptionPreferencesOptions struct {
+	IDType   IdentifierType
+	Language string
+}
+
+// GetCustomerSubscriptionPreferences returns a customer's topic subscription
+// state. See https://docs.customer.io/api/app/#operation/getPersonSubscriptionPreferences
+func (c *APIClient) GetCustomerSubscriptionPreferences(ctx context.Context, customerID string, opts CustomerSubscriptionPreferencesOptions) (*SubscriptionPreferencesResponse, error) {
+	if customerID == "" {
+		return nil, ParamError{Param: "customerID"}
+	}
+
+	q := newQuery().setString("id_type", string(opts.IDType)).setString("language", opts.Language)
+	requestPath := formatPath("/v1/customers/%s/subscription_preferences", customerID) + q.String()
+
+	var resp SubscriptionPreferencesResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// getCustomersAttributesRequest is the POST /v1/customers/attributes body.
+type getCustomersAttributesRequest struct {
+	IDs []string `json:"ids"`
+}
+
+// CustomerAttributesEntry wraps one customer in GetCustomersAttributesResponse.
+type CustomerAttributesEntry struct {
+	Customer Customer `json:"customer"`
+}
+
+// GetCustomersAttributesResponse is the decoded shape of POST /v1/customers/attributes.
+type GetCustomersAttributesResponse struct {
+	Customers []CustomerAttributesEntry `json:"customers"`
+}
+
+// GetCustomersAttributes returns profile attributes for up to 1000
+// customers by id in one call. See https://docs.customer.io/api/app/#operation/getCustomersAttributes
+func (c *APIClient) GetCustomersAttributes(ctx context.Context, ids []string) (*GetCustomersAttributesResponse, error) {
+	if len(ids) == 0 {
+		return nil, ParamError{Param: "ids"}
+	}
+
+	var resp GetCustomersAttributesResponse
+	if err := c.doJSON(ctx, "POST", "/v1/customers/attributes", getCustomersAttributesRequest{IDs: ids}, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// SubscriptionCenterTokenResponse is the decoded shape of
+// GET /v1/subscription_center/{customerId}/token.
+type SubscriptionCenterTokenResponse struct {
+	Token string `json:"token"`
+	URL   string `json:"url,omitempty"`
+}
+
+// GetSubscriptionCenterToken returns a signed token (and hosted URL) a
+// customer can use to manage their own subscription preferences.
+// See https://docs.customer.io/api/app/#operation/getSubscriptionCenterAccessToken
+func (c *APIClient) GetSubscriptionCenterToken(ctx context.Context, customerID string) (*SubscriptionCenterTokenResponse, error) {
+	if customerID == "" {
+		return nil, ParamError{Param: "customerID"}
+	}
+
+	requestPath := formatPath("/v1/subscription_center/%s/token", customerID)
+
+	var resp SubscriptionCenterTokenResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/customers.go
+++ b/customers.go
@@ -134,26 +134,33 @@ func (c *APIClient) GetCustomerActivities(ctx context.Context, customerID string
 	return &resp, nil
 }
 
-// Message is an entry from GET /v1/customers/{id}/messages — a sent
-// email/push/SMS/etc. and its delivery metadata. Open/click/bounce state is
-// not part of this object; join against GetCustomerActivities (or
-// GetMessage's associations) for delivery lifecycle events.
+// Message is a sent email/push/SMS/etc. and its delivery metadata — the
+// shared shape returned by GET /v1/customers/{id}/messages,
+// GET /v1/transactional/{id}/messages, and GET /v1/messages. Open/click/
+// bounce state is not part of this object; join against
+// GetCustomerActivities (or GetMessage's associations) for delivery
+// lifecycle events.
 type Message struct {
-	ID             string           `json:"id"`
-	DeduplicateID  string           `json:"deduplicate_id,omitempty"`
-	CustomerID     string           `json:"customer_id,omitempty"`
-	CampaignID     int              `json:"campaign_id,omitempty"`
-	ActionID       int              `json:"action_id,omitempty"`
-	Recipient      string           `json:"recipient,omitempty"`
-	Subject        string           `json:"subject,omitempty"`
-	Metrics        map[string]int64 `json:"metrics,omitempty"`
-	Created        int64            `json:"created,omitempty"`
-	FailureMessage string           `json:"failure_message,omitempty"`
-	NewsletterID   *int             `json:"newsletter_id,omitempty"`
-	ContentID      *int             `json:"content_id,omitempty"`
-	BroadcastID    *int             `json:"broadcast_id,omitempty"`
-	Type           string           `json:"type,omitempty"`
-	Forgotten      bool             `json:"forgotten,omitempty"`
+	ID                  string               `json:"id"`
+	DeduplicateID       string               `json:"deduplicate_id,omitempty"`
+	CustomerID          string               `json:"customer_id,omitempty"`
+	CustomerIdentifiers *CustomerIdentifiers `json:"customer_identifiers,omitempty"`
+	CampaignID          int                  `json:"campaign_id,omitempty"`
+	ActionID            int                  `json:"action_id,omitempty"`
+	ParentActionID      *int                 `json:"parent_action_id,omitempty"`
+	TriggerEventID      string               `json:"trigger_event_id,omitempty"`
+	Recipient           string               `json:"recipient,omitempty"`
+	Subject             string               `json:"subject,omitempty"`
+	Metrics             map[string]int64     `json:"metrics,omitempty"`
+	Created             int64                `json:"created,omitempty"`
+	FailureMessage      string               `json:"failure_message,omitempty"`
+	NewsletterID        *int                 `json:"newsletter_id,omitempty"`
+	ContentID           *int                 `json:"content_id,omitempty"`
+	BroadcastID         *int                 `json:"broadcast_id,omitempty"`
+	Type                string               `json:"type,omitempty"`
+	Forgotten           bool                 `json:"forgotten,omitempty"`
+	// TrackedResponses' shape isn't documented; kept opaque rather than guessed.
+	TrackedResponses any `json:"tracked_responses,omitempty"`
 }
 
 // MessagesResponse is the decoded shape of GET /v1/customers/{id}/messages.

--- a/customers_test.go
+++ b/customers_test.go
@@ -1,0 +1,286 @@
+package customerio_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/customerio/go-customerio/v3"
+)
+
+func TestSearchCustomers(t *testing.T) {
+	ctx := context.Background()
+
+	resp := map[string]any{
+		"identifiers": []map[string]any{{"id": "1", "email": "a@example.com", "cio_id": "c1"}},
+		"ids":         []string{"1"},
+		"next":        "MDox",
+	}
+	api, rec := apiServer(t, 200, resp)
+
+	filter := customerio.FilterByAttribute("email", customerio.FilterOperatorEq, "a@example.com")
+	got, err := api.SearchCustomers(ctx, filter, customerio.PaginationOptions{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "POST", "/v1/customers?limit=10")
+
+	want := &customerio.SearchCustomersResponse{
+		Identifiers: []customerio.CustomerIdentifiers{{ID: "1", Email: "a@example.com", CioID: "c1"}},
+		IDs:         []string{"1"},
+		Next:        "MDox",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+
+	wantBody := map[string]any{
+		"filter": map[string]any{"attribute": map[string]any{"field": "email", "operator": "eq", "value": "a@example.com"}},
+	}
+	assertJSONEqual(t, rec.body, wantBody)
+}
+
+func TestSearchCustomersComposedFilter(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"identifiers": []any{}, "ids": []any{}})
+
+	filter := customerio.FilterAnd(
+		customerio.FilterBySegment(7),
+		customerio.FilterNot(customerio.FilterByAttribute("plan", customerio.FilterOperatorExists, "")),
+	)
+	if _, err := api.SearchCustomers(context.Background(), filter, customerio.PaginationOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "POST", "/v1/customers")
+
+	wantBody := map[string]any{
+		"filter": map[string]any{
+			"and": []any{
+				map[string]any{"segment": map[string]any{"id": float64(7)}},
+				map[string]any{"not": map[string]any{"attribute": map[string]any{"field": "plan", "operator": "exists"}}},
+			},
+		},
+	}
+	assertJSONEqual(t, rec.body, wantBody)
+}
+
+func TestGetCustomersByEmail(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetCustomersByEmail(context.Background(), ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "email")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"results": []map[string]any{{"id": "1", "email": "a@example.com"}}})
+	got, err := api.GetCustomersByEmail(context.Background(), "a@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/customers?email=a%40example.com")
+	want := &customerio.GetCustomersByEmailResponse{Results: []customerio.CustomerIdentifiers{{ID: "1", Email: "a@example.com"}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestGetAttributes(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetAttributes(context.Background(), "", ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "id")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"customer": map[string]any{
+		"id":           "1",
+		"attributes":   map[string]any{"plan": "gold"},
+		"unsubscribed": false,
+	}})
+	got, err := api.GetAttributes(context.Background(), "1", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/customers/1/attributes?id_type=id")
+	if got.Customer.Attributes["plan"] != "gold" {
+		t.Errorf("unexpected attributes: %#v", got.Customer.Attributes)
+	}
+
+	api2, rec2 := apiServer(t, 200, map[string]any{"customer": map[string]any{"id": "a@example.com"}})
+	if _, err := api2.GetAttributes(context.Background(), "a@example.com", customerio.IdentifierTypeEmail); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec2, "GET", "/v1/customers/a@example.com/attributes?id_type=email")
+}
+
+func TestGetCustomerActivities(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetCustomerActivities(context.Background(), "", customerio.CustomerActivitiesOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "customerID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"activities": []map[string]any{
+		{"id": "act1", "type": "sent_email", "timestamp": 1397566226},
+	}, "next": "abc"})
+	got, err := api.GetCustomerActivities(context.Background(), "1", customerio.CustomerActivitiesOptions{
+		IDType:            customerio.IdentifierTypeID,
+		Type:              "sent_email",
+		PaginationOptions: customerio.PaginationOptions{Limit: 5},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/customers/1/activities?id_type=id&limit=5&type=sent_email")
+	if len(got.Activities) != 1 || got.Activities[0].ID != "act1" || got.Next != "abc" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetCustomerMessages(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetCustomerMessages(context.Background(), "", customerio.CustomerMessagesOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "customerID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"messages": []map[string]any{
+		{"id": "m1", "type": "email", "subject": "hi", "created": 1700000000},
+	}})
+	got, err := api.GetCustomerMessages(context.Background(), "a@example.com", customerio.CustomerMessagesOptions{
+		IDType:  customerio.IdentifierTypeEmail,
+		StartTS: 1690000000,
+		EndTS:   1700000000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/customers/a@example.com/messages?end_ts=1700000000&id_type=email&start_ts=1690000000")
+	if len(got.Messages) != 1 || got.Messages[0].Subject != "hi" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetCustomerRelationships(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetCustomerRelationships(context.Background(), "", customerio.PaginationOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "customerID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"cio_relationships": []map[string]any{
+		{"object_type_id": "1", "identifiers": map[string]any{"object_id": "ae3000"}},
+	}, "next": ""})
+	got, err := api.GetCustomerRelationships(context.Background(), "1", customerio.PaginationOptions{Start: "cursor1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/customers/1/relationships?start=cursor1")
+	if len(got.Relationships) != 1 || got.Relationships[0].Identifiers.ObjectID != "ae3000" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetCustomerSegments(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetCustomerSegments(context.Background(), "", ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "customerID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"segments": []map[string]any{{"id": 3, "name": "VIP"}}})
+	got, err := api.GetCustomerSegments(context.Background(), "1", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/customers/1/segments?id_type=id")
+	if len(got.Segments) != 1 || got.Segments[0].Name != "VIP" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetCustomerSubscriptionPreferences(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetCustomerSubscriptionPreferences(context.Background(), "", customerio.CustomerSubscriptionPreferencesOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "customerID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"customer": map[string]any{
+		"id": "1",
+		"topics": []map[string]any{
+			{"id": 1, "subscribed": true, "name": "Offers"},
+		},
+		"unsubscribed": false,
+	}})
+	got, err := api.GetCustomerSubscriptionPreferences(context.Background(), "1", customerio.CustomerSubscriptionPreferencesOptions{Language: "en"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/customers/1/subscription_preferences?language=en")
+	if len(got.Customer.Topics) != 1 || got.Customer.Topics[0].Name != "Offers" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetCustomersAttributes(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetCustomersAttributes(context.Background(), nil); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "ids")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"customers": []map[string]any{
+		{"customer": map[string]any{"id": "1", "attributes": map[string]any{"plan": "gold"}}},
+	}})
+	got, err := api.GetCustomersAttributes(context.Background(), []string{"1", "2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "POST", "/v1/customers/attributes")
+	wantBody := map[string]any{"ids": []any{"1", "2"}}
+	assertJSONEqual(t, rec.body, wantBody)
+	if len(got.Customers) != 1 || got.Customers[0].Customer.ID != "1" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetSubscriptionCenterToken(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetSubscriptionCenterToken(context.Background(), ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "customerID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"token": "tok123", "url": "https://track.customer.io/u/i/tok123/"})
+	got, err := api.GetSubscriptionCenterToken(context.Background(), "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/subscription_center/1/token")
+	if got.Token != "tok123" {
+		t.Errorf("unexpected token: %#v", got)
+	}
+}
+
+func TestCustomersEndpointsError(t *testing.T) {
+	api, _ := apiServer(t, 404, map[string]any{"errors": []map[string]any{{"detail": "not found"}}})
+
+	_, err := api.GetAttributes(context.Background(), "missing", "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	cioErr, ok := err.(*customerio.CustomerIOError)
+	if !ok {
+		t.Fatalf("expected *CustomerIOError, got %T", err)
+	}
+	if cioErr.StatusCode() != 404 {
+		t.Errorf("expected status 404, got %d", cioErr.StatusCode())
+	}
+}

--- a/filter.go
+++ b/filter.go
@@ -1,0 +1,103 @@
+package customerio
+
+// FilterOperator is a comparison operator supported in attribute and object
+// attribute conditions.
+type FilterOperator string
+
+const (
+	FilterOperatorEq     FilterOperator = "eq"
+	FilterOperatorExists FilterOperator = "exists"
+)
+
+// AudienceFilter composes a boolean filter over customers, used by
+// SearchCustomers and CreateCustomersExport. Build a leaf with
+// FilterBySegment or FilterByAttribute; compose leaves with FilterAnd,
+// FilterOr, or FilterNot. Exactly one of the fields is set on any given
+// node — this mirrors the AudienceFilter union type in customerio-node's
+// lib/types.ts, flattened to a single struct since Go has no union types.
+type AudienceFilter struct {
+	Segment   *SegmentCondition   `json:"segment,omitempty"`
+	Attribute *AttributeCondition `json:"attribute,omitempty"`
+	And       []AudienceFilter    `json:"and,omitempty"`
+	Or        []AudienceFilter    `json:"or,omitempty"`
+	Not       *AudienceFilter     `json:"not,omitempty"`
+}
+
+// SegmentCondition matches everyone in a given segment.
+type SegmentCondition struct {
+	ID int `json:"id"`
+}
+
+// AttributeCondition matches people whose attribute satisfies an operator
+// against a value. Value is only meaningful for FilterOperatorEq; omit it
+// for FilterOperatorExists.
+type AttributeCondition struct {
+	Field    string         `json:"field"`
+	Operator FilterOperator `json:"operator"`
+	Value    string         `json:"value,omitempty"`
+}
+
+// FilterBySegment builds a leaf AudienceFilter matching everyone in segment id.
+func FilterBySegment(id int) AudienceFilter {
+	return AudienceFilter{Segment: &SegmentCondition{ID: id}}
+}
+
+// FilterByAttribute builds a leaf AudienceFilter matching people whose
+// attribute field satisfies operator (and value, for FilterOperatorEq).
+func FilterByAttribute(field string, operator FilterOperator, value string) AudienceFilter {
+	return AudienceFilter{Attribute: &AttributeCondition{Field: field, Operator: operator, Value: value}}
+}
+
+// FilterAnd composes filters that must all match.
+func FilterAnd(filters ...AudienceFilter) AudienceFilter {
+	return AudienceFilter{And: filters}
+}
+
+// FilterOr composes filters where at least one must match.
+func FilterOr(filters ...AudienceFilter) AudienceFilter {
+	return AudienceFilter{Or: filters}
+}
+
+// FilterNot negates a filter.
+func FilterNot(filter AudienceFilter) AudienceFilter {
+	return AudienceFilter{Not: &filter}
+}
+
+// ObjectFilter composes a boolean filter over objects, used by FindObjects.
+// Build a leaf with ObjectFilterByAttribute; compose leaves with
+// ObjectFilterAnd, ObjectFilterOr, or ObjectFilterNot.
+type ObjectFilter struct {
+	ObjectAttribute *ObjectAttributeCondition `json:"object_attribute,omitempty"`
+	And             []ObjectFilter            `json:"and,omitempty"`
+	Or              []ObjectFilter            `json:"or,omitempty"`
+	Not             *ObjectFilter             `json:"not,omitempty"`
+}
+
+// ObjectAttributeCondition matches objects of type TypeID whose attribute
+// field satisfies operator (and value, for FilterOperatorEq).
+type ObjectAttributeCondition struct {
+	Field    string         `json:"field"`
+	Operator FilterOperator `json:"operator"`
+	Value    string         `json:"value,omitempty"`
+	TypeID   int            `json:"type_id"`
+}
+
+// ObjectFilterByAttribute builds a leaf ObjectFilter.
+func ObjectFilterByAttribute(field string, operator FilterOperator, value string, typeID int) ObjectFilter {
+	return ObjectFilter{ObjectAttribute: &ObjectAttributeCondition{Field: field, Operator: operator, Value: value, TypeID: typeID}}
+}
+
+// ObjectFilterAnd composes filters that must all match.
+func ObjectFilterAnd(filters ...ObjectFilter) ObjectFilter {
+	return ObjectFilter{And: filters}
+}
+
+// ObjectFilterOr composes filters where at least one must match.
+func ObjectFilterOr(filters ...ObjectFilter) ObjectFilter {
+	return ObjectFilter{Or: filters}
+}
+
+// ObjectFilterNot negates a filter.
+func ObjectFilterNot(filter ObjectFilter) ObjectFilter {
+	return ObjectFilter{Not: &filter}
+}

--- a/messages.go
+++ b/messages.go
@@ -1,0 +1,127 @@
+package customerio
+
+import "context"
+
+// MessagesOptions filters GetMessages, the cross-resource message list —
+// unlike GetCustomerMessages/GetTransactionalMessageDeliveries, it isn't
+// scoped to a single customer or transactional template; the *_id filters
+// narrow it to a specific campaign/action/newsletter/transactional/etc.
+type MessagesOptions struct {
+	PaginationOptions
+	Drafts              *bool
+	Metric              string
+	Type                string
+	CampaignID          string
+	ActionID            string
+	NewsletterID        string
+	TransactionalID     string
+	TriggerID           string
+	TemplateID          string
+	ContentID           string
+	StartTS             int64
+	EndTS               int64
+	Associations        *bool
+	GetTrackedResponses *bool
+}
+
+// GetMessages returns messages across the whole workspace, most recent
+// first, optionally filtered to one campaign/action/newsletter/
+// transactional template/trigger/template/content id.
+// See https://docs.customer.io/api/app/#operation/getMessages
+func (c *APIClient) GetMessages(ctx context.Context, opts MessagesOptions) (*MessagesResponse, error) {
+	q := opts.PaginationOptions.apply(newQuery()).
+		setBool("drafts", opts.Drafts).
+		setString("metric", opts.Metric).
+		setString("type", opts.Type).
+		setString("campaign_id", opts.CampaignID).
+		setString("action_id", opts.ActionID).
+		setString("newsletter_id", opts.NewsletterID).
+		setString("transactional_id", opts.TransactionalID).
+		setString("trigger_id", opts.TriggerID).
+		setString("template_id", opts.TemplateID).
+		setString("content_id", opts.ContentID).
+		setInt64("start_ts", opts.StartTS).
+		setInt64("end_ts", opts.EndTS).
+		setBool("associations", opts.Associations).
+		setBool("get_tracked_responses", opts.GetTrackedResponses)
+
+	requestPath := "/v1/messages" + q.String()
+
+	var resp MessagesResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// MessageOptions controls GetMessage's response detail.
+type MessageOptions struct {
+	ArchivedMessage     *bool
+	Associations        *bool
+	GetTrackedResponses *bool
+}
+
+// MessageResponse wraps a single Message.
+type MessageResponse struct {
+	Message Message `json:"message"`
+}
+
+// GetMessage returns one message by id.
+// See https://docs.customer.io/api/app/#operation/getMessage
+func (c *APIClient) GetMessage(ctx context.Context, messageID string, opts MessageOptions) (*MessageResponse, error) {
+	if messageID == "" {
+		return nil, ParamError{Param: "messageID"}
+	}
+
+	q := newQuery().
+		setBool("archived_message", opts.ArchivedMessage).
+		setBool("associations", opts.Associations).
+		setBool("get_tracked_responses", opts.GetTrackedResponses)
+	requestPath := formatPath("/v1/messages/%s", messageID) + q.String()
+
+	var resp MessageResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// ArchivedMessage is a message's full rendered content, as delivered.
+type ArchivedMessage struct {
+	ID            string            `json:"id,omitempty"`
+	Body          string            `json:"body,omitempty"`
+	From          string            `json:"from,omitempty"`
+	ReplyTo       string            `json:"reply_to,omitempty"`
+	Recipient     string            `json:"recipient,omitempty"`
+	Subject       string            `json:"subject,omitempty"`
+	CC            string            `json:"cc,omitempty"`
+	BCC           string            `json:"bcc,omitempty"`
+	FakeBCC       *bool             `json:"fake_bcc,omitempty"`
+	PreheaderText string            `json:"preheader_text,omitempty"`
+	URL           string            `json:"url,omitempty"`
+	RequestMethod string            `json:"request_method,omitempty"`
+	Headers       map[string]string `json:"headers,omitempty"`
+	Forgotten     bool              `json:"forgotten,omitempty"`
+}
+
+// ArchivedMessageResponse is the decoded shape of
+// GET /v1/messages/{id}/archived_message.
+type ArchivedMessageResponse struct {
+	ArchivedMessage ArchivedMessage `json:"archived_message"`
+}
+
+// GetArchivedMessage returns a message's full rendered content. This
+// endpoint is rate-limited by the API (10 requests/second) — the returned
+// error's status will be 429 if that limit is exceeded.
+// See https://docs.customer.io/api/app/#operation/getArchivedMessage
+func (c *APIClient) GetArchivedMessage(ctx context.Context, messageID string) (*ArchivedMessageResponse, error) {
+	if messageID == "" {
+		return nil, ParamError{Param: "messageID"}
+	}
+
+	var resp ArchivedMessageResponse
+	if err := c.doJSON(ctx, "GET", formatPath("/v1/messages/%s/archived_message", messageID), nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/messages_test.go
+++ b/messages_test.go
@@ -1,0 +1,87 @@
+package customerio_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/customerio/go-customerio/v3"
+)
+
+func TestGetMessages(t *testing.T) {
+	drafts := false
+	api, rec := apiServer(t, 200, map[string]any{"messages": []map[string]any{
+		{"id": "m1", "type": "email", "campaign_id": 4},
+	}})
+	got, err := api.GetMessages(context.Background(), customerio.MessagesOptions{
+		Drafts:            &drafts,
+		Type:              "email",
+		CampaignID:        "4",
+		PaginationOptions: customerio.PaginationOptions{Limit: 50},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/messages?campaign_id=4&drafts=false&limit=50&type=email")
+	if len(got.Messages) != 1 || got.Messages[0].CampaignID != 4 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetMessagesNoOptions(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"messages": []any{}})
+	if _, err := api.GetMessages(context.Background(), customerio.MessagesOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/messages")
+}
+
+func TestGetMessage(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetMessage(context.Background(), "", customerio.MessageOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "messageID")
+	}
+
+	associations := true
+	api, rec := apiServer(t, 200, map[string]any{"message": map[string]any{"id": "m1", "subject": "hi"}})
+	got, err := api.GetMessage(context.Background(), "m1", customerio.MessageOptions{Associations: &associations})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/messages/m1?associations=true")
+	if got.Message.Subject != "hi" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetArchivedMessage(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetArchivedMessage(context.Background(), ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "messageID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"archived_message": map[string]any{"id": "m1", "body": "<html></html>"}})
+	got, err := api.GetArchivedMessage(context.Background(), "m1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/messages/m1/archived_message")
+	if got.ArchivedMessage.Body != "<html></html>" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetArchivedMessageRateLimited(t *testing.T) {
+	api, _ := apiServer(t, 429, map[string]any{"errors": []map[string]any{{"detail": "rate limited"}}})
+	_, err := api.GetArchivedMessage(context.Background(), "m1")
+	cioErr, ok := err.(*customerio.CustomerIOError)
+	if !ok {
+		t.Fatalf("expected *CustomerIOError, got %T", err)
+	}
+	if cioErr.StatusCode() != 429 {
+		t.Errorf("expected status 429, got %d", cioErr.StatusCode())
+	}
+}

--- a/objects.go
+++ b/objects.go
@@ -1,0 +1,143 @@
+package customerio
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// ObjectAttributes is the object payload returned by GetObjectAttributes.
+// ObjectTypeID is decoded leniently (json.Number) since the documented
+// schema types it as a string here but as an integer on other object
+// endpoints.
+type ObjectAttributes struct {
+	ObjectTypeID json.Number       `json:"object_type_id,omitempty"`
+	Identifiers  ObjectIdentifiers `json:"identifiers"`
+	Attributes   map[string]any    `json:"attributes,omitempty"`
+	Timestamps   map[string]int64  `json:"timestamps,omitempty"`
+}
+
+// ObjectAttributesResponse is the decoded shape of
+// GET /v1/objects/{objectTypeId}/{objectId}/attributes.
+type ObjectAttributesResponse struct {
+	Object ObjectAttributes `json:"object"`
+}
+
+// GetObjectAttributes returns an object's attributes. idType selects which
+// kind of identifier objectID is; pass "" to let the API apply its default.
+// See https://docs.customer.io/api/app/#operation/getObjectAttributes
+func (c *APIClient) GetObjectAttributes(ctx context.Context, objectTypeID, objectID string, idType ObjectIdentifierType) (*ObjectAttributesResponse, error) {
+	if objectTypeID == "" {
+		return nil, ParamError{Param: "objectTypeID"}
+	}
+	if objectID == "" {
+		return nil, ParamError{Param: "objectID"}
+	}
+
+	requestPath := formatPath("/v1/objects/%s/%s/attributes", objectTypeID, objectID) +
+		newQuery().setString("id_type", string(idType)).String()
+
+	var resp ObjectAttributesResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// ObjectRelationship is an object's relationship to a customer.
+// ObjectTypeID is decoded leniently (json.Number): see ObjectAttributes.
+type ObjectRelationship struct {
+	ObjectTypeID       json.Number         `json:"object_type_id,omitempty"`
+	ObjectTypeDisabled bool                `json:"object_type_disabled,omitempty"`
+	Identifiers        CustomerIdentifiers `json:"identifiers"`
+}
+
+// ObjectRelationshipsResponse is the decoded shape of
+// GET /v1/objects/{objectTypeId}/{objectId}/relationships.
+type ObjectRelationshipsResponse struct {
+	Relationships []ObjectRelationship `json:"cio_relationships"`
+	Next          string               `json:"next,omitempty"`
+}
+
+// ObjectRelationshipsOptions filters GetObjectRelationships.
+type ObjectRelationshipsOptions struct {
+	PaginationOptions
+	IDType ObjectIdentifierType
+}
+
+// GetObjectRelationships returns the customers related to an object.
+// See https://docs.customer.io/api/app/#operation/getObjectRelationships
+func (c *APIClient) GetObjectRelationships(ctx context.Context, objectTypeID, objectID string, opts ObjectRelationshipsOptions) (*ObjectRelationshipsResponse, error) {
+	if objectTypeID == "" {
+		return nil, ParamError{Param: "objectTypeID"}
+	}
+	if objectID == "" {
+		return nil, ParamError{Param: "objectID"}
+	}
+
+	q := opts.PaginationOptions.apply(newQuery()).setString("id_type", string(opts.IDType))
+	requestPath := formatPath("/v1/objects/%s/%s/relationships", objectTypeID, objectID) + q.String()
+
+	var resp ObjectRelationshipsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// findObjectsRequest is the POST /v1/objects body.
+type findObjectsRequest struct {
+	ObjectTypeID string       `json:"object_type_id"`
+	Filter       ObjectFilter `json:"filter"`
+}
+
+// FindObjectsResponse is the decoded shape of POST /v1/objects.
+type FindObjectsResponse struct {
+	Identifiers []ObjectIdentifiers `json:"identifiers"`
+	IDs         []string            `json:"ids"`
+	Next        string              `json:"next,omitempty"`
+}
+
+// FindObjects finds objects of type objectTypeID matching filter (built
+// with ObjectFilterByAttribute and the ObjectFilterAnd/Or/Not combinators).
+// See https://docs.customer.io/api/app/#operation/findObjects
+func (c *APIClient) FindObjects(ctx context.Context, objectTypeID string, filter ObjectFilter, opts PaginationOptions) (*FindObjectsResponse, error) {
+	if objectTypeID == "" {
+		return nil, ParamError{Param: "objectTypeID"}
+	}
+
+	requestPath := "/v1/objects" + opts.apply(newQuery()).String()
+
+	var resp FindObjectsResponse
+	req := findObjectsRequest{ObjectTypeID: objectTypeID, Filter: filter}
+	if err := c.doJSON(ctx, "POST", requestPath, req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// ObjectType describes an object type configured in a workspace (e.g. a
+// "Company" or "Concert" schema).
+type ObjectType struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	SingularName string `json:"singular_name,omitempty"`
+	Slug         string `json:"slug,omitempty"`
+	SingularSlug string `json:"singular_slug,omitempty"`
+	Enabled      bool   `json:"enabled"`
+	Icon         string `json:"icon,omitempty"`
+}
+
+// ListObjectTypesResponse is the decoded shape of GET /v1/object_types.
+type ListObjectTypesResponse struct {
+	Types []ObjectType `json:"types"`
+}
+
+// ListObjectTypes returns every object type configured in the workspace.
+// See https://docs.customer.io/api/app/#operation/listObjectTypes
+func (c *APIClient) ListObjectTypes(ctx context.Context) (*ListObjectTypesResponse, error) {
+	var resp ListObjectTypesResponse
+	if err := c.doJSON(ctx, "GET", "/v1/object_types", nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/objects_test.go
+++ b/objects_test.go
@@ -1,0 +1,138 @@
+package customerio_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/customerio/go-customerio/v3"
+)
+
+func TestGetObjectAttributes(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	ctx := context.Background()
+
+	if _, err := api.GetObjectAttributes(ctx, "", "obj1", ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "objectTypeID")
+	}
+	if _, err := api.GetObjectAttributes(ctx, "1", "", ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "objectID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"object": map[string]any{
+		"object_type_id": "1",
+		"identifiers":    map[string]any{"object_id": "ae3000"},
+		"attributes":     map[string]any{"name": "Acme"},
+	}})
+	got, err := api.GetObjectAttributes(ctx, "1", "ae3000", customerio.ObjectIdentifierTypeObjectID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/objects/1/ae3000/attributes?id_type=object_id")
+	if got.Object.Identifiers.ObjectID != "ae3000" || got.Object.Attributes["name"] != "Acme" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetObjectRelationships(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	ctx := context.Background()
+
+	if _, err := api.GetObjectRelationships(ctx, "", "obj1", customerio.ObjectRelationshipsOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "objectTypeID")
+	}
+	if _, err := api.GetObjectRelationships(ctx, "1", "", customerio.ObjectRelationshipsOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "objectID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"cio_relationships": []map[string]any{
+		{"identifiers": map[string]any{"cio_id": "cio1", "id": "acmeInc"}, "object_type_id": "1", "object_type_disabled": false},
+	}})
+	got, err := api.GetObjectRelationships(ctx, "1", "ae3000", customerio.ObjectRelationshipsOptions{
+		PaginationOptions: customerio.PaginationOptions{Limit: 20},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/objects/1/ae3000/relationships?limit=20")
+	if len(got.Relationships) != 1 || got.Relationships[0].Identifiers.ID != "acmeInc" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestFindObjects(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	ctx := context.Background()
+
+	if _, err := api.FindObjects(ctx, "", customerio.ObjectFilter{}, customerio.PaginationOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "objectTypeID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{
+		"identifiers": []map[string]any{{"cio_object_id": "ob020101", "object_id": "ae3000"}},
+		"ids":         []string{"ae3000"},
+	})
+	filter := customerio.ObjectFilterByAttribute("name", customerio.FilterOperatorEq, "Acme", 1)
+	got, err := api.FindObjects(ctx, "1", filter, customerio.PaginationOptions{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "POST", "/v1/objects?limit=10")
+
+	wantBody := map[string]any{
+		"object_type_id": "1",
+		"filter": map[string]any{
+			"object_attribute": map[string]any{"field": "name", "operator": "eq", "value": "Acme", "type_id": float64(1)},
+		},
+	}
+	assertJSONEqual(t, rec.body, wantBody)
+	if len(got.Identifiers) != 1 || got.Identifiers[0].ObjectID != "ae3000" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestFindObjectsComposedFilter(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"identifiers": []any{}, "ids": []any{}})
+
+	filter := customerio.ObjectFilterOr(
+		customerio.ObjectFilterByAttribute("tier", customerio.FilterOperatorEq, "gold", 1),
+		customerio.ObjectFilterNot(customerio.ObjectFilterByAttribute("archived", customerio.FilterOperatorExists, "", 1)),
+	)
+	if _, err := api.FindObjects(context.Background(), "1", filter, customerio.PaginationOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	wantBody := map[string]any{
+		"object_type_id": "1",
+		"filter": map[string]any{
+			"or": []any{
+				map[string]any{"object_attribute": map[string]any{"field": "tier", "operator": "eq", "value": "gold", "type_id": float64(1)}},
+				map[string]any{"not": map[string]any{"object_attribute": map[string]any{"field": "archived", "operator": "exists", "type_id": float64(1)}}},
+			},
+		},
+	}
+	assertJSONEqual(t, rec.body, wantBody)
+}
+
+func TestListObjectTypes(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"types": []map[string]any{
+		{"id": "1", "name": "Concerts", "singular_name": "Concert", "enabled": true},
+	}})
+	got, err := api.ListObjectTypes(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/object_types")
+	if len(got.Types) != 1 || got.Types[0].Name != "Concerts" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}

--- a/pagination.go
+++ b/pagination.go
@@ -1,0 +1,26 @@
+package customerio
+
+// PaginationOptions controls paging on App API list/search endpoints.
+// Start is an opaque cursor returned by a previous response's "next" field,
+// not a page number or offset — pass it back verbatim to fetch the next
+// page. Limit caps the number of results per page; 0 lets the API apply its
+// default.
+type PaginationOptions struct {
+	Start string
+	Limit int
+}
+
+func (o PaginationOptions) apply(q *queryBuilder) *queryBuilder {
+	return q.setString("start", o.Start).setInt("limit", o.Limit)
+}
+
+// ObjectIdentifierType identifies which kind of id a request supplies for an
+// object (as opposed to IdentifierType, which is for customers).
+type ObjectIdentifierType string
+
+const (
+	// ObjectIdentifierTypeObjectID selects the caller-supplied object_id.
+	ObjectIdentifierTypeObjectID ObjectIdentifierType = "object_id"
+	// ObjectIdentifierTypeCioObjectID selects Customer.io's generated cio_object_id.
+	ObjectIdentifierTypeCioObjectID ObjectIdentifierType = "cio_object_id"
+)

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -1,0 +1,52 @@
+package customerio
+
+import "context"
+
+// SubscriptionTopic is a topic customers can subscribe to (e.g. "Product Updates").
+type SubscriptionTopic struct {
+	ID                  int    `json:"id"`
+	Identifier          string `json:"identifier,omitempty"`
+	Name                string `json:"name"`
+	Description         string `json:"description,omitempty"`
+	SubscribedByDefault bool   `json:"subscribed_by_default"`
+}
+
+// ListSubscriptionTopicsResponse is the decoded shape of GET /v1/subscription_topics.
+type ListSubscriptionTopicsResponse struct {
+	Topics []SubscriptionTopic `json:"topics"`
+}
+
+// ListSubscriptionTopics returns every subscription topic defined in the workspace.
+// See https://docs.customer.io/api/app/#operation/listSubscriptionTopics
+func (c *APIClient) ListSubscriptionTopics(ctx context.Context) (*ListSubscriptionTopicsResponse, error) {
+	var resp ListSubscriptionTopicsResponse
+	if err := c.doJSON(ctx, "GET", "/v1/subscription_topics", nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// SubscriptionChannel is a delivery channel (email, push, SMS, ...)
+// customers can opt in or out of.
+type SubscriptionChannel struct {
+	ID                  int    `json:"id"`
+	Type                string `json:"type"`
+	Name                string `json:"name"`
+	Description         string `json:"description,omitempty"`
+	SubscribedByDefault bool   `json:"subscribed_by_default"`
+}
+
+// ListSubscriptionChannelsResponse is the decoded shape of GET /v1/subscription_channels.
+type ListSubscriptionChannelsResponse struct {
+	Channels []SubscriptionChannel `json:"channels"`
+}
+
+// ListSubscriptionChannels returns every subscription channel defined in the workspace.
+// See https://docs.customer.io/api/app/#operation/listSubscriptionChannels
+func (c *APIClient) ListSubscriptionChannels(ctx context.Context) (*ListSubscriptionChannelsResponse, error) {
+	var resp ListSubscriptionChannelsResponse
+	if err := c.doJSON(ctx, "GET", "/v1/subscription_channels", nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -1,0 +1,34 @@
+package customerio_test
+
+import (
+	"context"
+	"testing"
+)
+
+func TestListSubscriptionTopics(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"topics": []map[string]any{
+		{"id": 4, "identifier": "topic_4", "name": "Product Updates", "subscribed_by_default": false},
+	}})
+	got, err := api.ListSubscriptionTopics(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/subscription_topics")
+	if len(got.Topics) != 1 || got.Topics[0].Name != "Product Updates" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestListSubscriptionChannels(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"channels": []map[string]any{
+		{"id": 1, "type": "email", "name": "Email", "subscribed_by_default": true},
+	}})
+	got, err := api.ListSubscriptionChannels(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/subscription_channels")
+	if len(got.Channels) != 1 || got.Channels[0].Type != "email" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}

--- a/transactional_messages.go
+++ b/transactional_messages.go
@@ -1,0 +1,319 @@
+package customerio
+
+import "context"
+
+// TransactionalMessage is a transactional message template's metadata (not
+// its content — see TransactionalMessageContent).
+type TransactionalMessage struct {
+	ID                 int    `json:"id"`
+	Name               string `json:"name,omitempty"`
+	Description        string `json:"description,omitempty"`
+	SendToUnsubscribed bool   `json:"send_to_unsubscribed"`
+	LinkTracking       bool   `json:"link_tracking"`
+	OpenTracking       bool   `json:"open_tracking"`
+	HideMessageBody    bool   `json:"hide_message_body"`
+	QueueDrafts        bool   `json:"queue_drafts"`
+	CreatedAt          int64  `json:"created_at,omitempty"`
+	UpdatedAt          int64  `json:"updated_at,omitempty"`
+}
+
+// ListTransactionalMessagesResponse is the decoded shape of GET /v1/transactional.
+type ListTransactionalMessagesResponse struct {
+	Messages []TransactionalMessage `json:"messages"`
+}
+
+// ListTransactionalMessages returns every transactional message template
+// defined in the workspace.
+// See https://docs.customer.io/api/app/#operation/listTransactionalMessages
+func (c *APIClient) ListTransactionalMessages(ctx context.Context) (*ListTransactionalMessagesResponse, error) {
+	var resp ListTransactionalMessagesResponse
+	if err := c.doJSON(ctx, "GET", "/v1/transactional", nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// TransactionalMessageResponse wraps a single TransactionalMessage.
+type TransactionalMessageResponse struct {
+	Message TransactionalMessage `json:"message"`
+}
+
+// GetTransactionalMessage returns one transactional message template's metadata.
+// See https://docs.customer.io/api/app/#operation/getTransactionalMessage
+func (c *APIClient) GetTransactionalMessage(ctx context.Context, transactionalID string) (*TransactionalMessageResponse, error) {
+	if transactionalID == "" {
+		return nil, ParamError{Param: "transactionalID"}
+	}
+
+	var resp TransactionalMessageResponse
+	if err := c.doJSON(ctx, "GET", formatPath("/v1/transactional/%s", transactionalID), nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// TransactionalMessageContent is one language variant's rendered content
+// for a transactional message template.
+type TransactionalMessageContent struct {
+	ID            int               `json:"id,omitempty"`
+	Name          string            `json:"name,omitempty"`
+	Created       int64             `json:"created,omitempty"`
+	Updated       int64             `json:"updated,omitempty"`
+	Body          string            `json:"body,omitempty"`
+	BodyAMP       string            `json:"body_amp,omitempty"`
+	Language      string            `json:"language,omitempty"`
+	Type          string            `json:"type,omitempty"`
+	From          string            `json:"from,omitempty"`
+	FromID        *int              `json:"from_id,omitempty"`
+	ReplyTo       string            `json:"reply_to,omitempty"`
+	ReplyToID     *int              `json:"reply_to_id,omitempty"`
+	Preprocessor  string            `json:"preprocessor,omitempty"`
+	Recipient     string            `json:"recipient,omitempty"`
+	Subject       string            `json:"subject,omitempty"`
+	PreheaderText string            `json:"preheader_text,omitempty"`
+	Headers       map[string]string `json:"headers,omitempty"`
+	CC            string            `json:"cc,omitempty"`
+	BCC           string            `json:"bcc,omitempty"`
+	FakeBCC       *bool             `json:"fake_bcc,omitempty"`
+}
+
+// TransactionalMessageContentsResponse is the decoded shape of
+// GET /v1/transactional/{id}/contents.
+type TransactionalMessageContentsResponse struct {
+	Contents []TransactionalMessageContent `json:"contents"`
+}
+
+// GetTransactionalMessageContents returns every language variant's content
+// for a transactional message template.
+// See https://docs.customer.io/api/app/#operation/getTransactionalMessageContents
+func (c *APIClient) GetTransactionalMessageContents(ctx context.Context, transactionalID string) (*TransactionalMessageContentsResponse, error) {
+	if transactionalID == "" {
+		return nil, ParamError{Param: "transactionalID"}
+	}
+
+	var resp TransactionalMessageContentsResponse
+	if err := c.doJSON(ctx, "GET", formatPath("/v1/transactional/%s/contents", transactionalID), nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// TransactionalMessageContentResponse wraps the content variant(s) returned
+// by the language and content-update endpoints.
+type TransactionalMessageContentResponse struct {
+	Content []TransactionalMessageContent `json:"content"`
+}
+
+// GetTransactionalMessageLanguage returns one language variant's content.
+// See https://docs.customer.io/api/app/#operation/getTransactionalMessageLanguage
+func (c *APIClient) GetTransactionalMessageLanguage(ctx context.Context, transactionalID, language string) (*TransactionalMessageContentResponse, error) {
+	if transactionalID == "" {
+		return nil, ParamError{Param: "transactionalID"}
+	}
+	if language == "" {
+		return nil, ParamError{Param: "language"}
+	}
+
+	var resp TransactionalMessageContentResponse
+	requestPath := formatPath("/v1/transactional/%s/language/%s", transactionalID, language)
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// UpdateTransactionalMessageLanguage creates or updates a language variant's
+// content. data is free-form (subject/body/etc — whichever fields you want
+// to set), matching the App API's own untyped request body for this endpoint.
+// See https://docs.customer.io/api/app/#operation/updateTransactionalMessageLanguage
+func (c *APIClient) UpdateTransactionalMessageLanguage(ctx context.Context, transactionalID, language string, data map[string]any) (*TransactionalMessageContentResponse, error) {
+	if transactionalID == "" {
+		return nil, ParamError{Param: "transactionalID"}
+	}
+	if language == "" {
+		return nil, ParamError{Param: "language"}
+	}
+
+	var resp TransactionalMessageContentResponse
+	requestPath := formatPath("/v1/transactional/%s/language/%s", transactionalID, language)
+	if err := c.doJSON(ctx, "PUT", requestPath, data, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// TransactionalDeliveriesOptions filters GetTransactionalMessageDeliveries.
+type TransactionalDeliveriesOptions struct {
+	PaginationOptions
+	Metric              string
+	StartTS             int64
+	EndTS               int64
+	GetTrackedResponses *bool
+}
+
+// TransactionalDeliveriesResponse is the decoded shape of
+// GET /v1/transactional/{id}/messages.
+type TransactionalDeliveriesResponse struct {
+	Messages []Message `json:"messages"`
+}
+
+// GetTransactionalMessageDeliveries returns the messages sent from a
+// transactional message template.
+// See https://docs.customer.io/api/app/#operation/getTransactionalMessageDeliveries
+func (c *APIClient) GetTransactionalMessageDeliveries(ctx context.Context, transactionalID string, opts TransactionalDeliveriesOptions) (*TransactionalDeliveriesResponse, error) {
+	if transactionalID == "" {
+		return nil, ParamError{Param: "transactionalID"}
+	}
+
+	q := opts.PaginationOptions.apply(newQuery()).
+		setString("metric", opts.Metric).
+		setInt64("start_ts", opts.StartTS).
+		setInt64("end_ts", opts.EndTS).
+		setBool("get_tracked_responses", opts.GetTrackedResponses)
+
+	requestPath := formatPath("/v1/transactional/%s/messages", transactionalID) + q.String()
+
+	var resp TransactionalDeliveriesResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// MetricsPeriod buckets a metrics time series into hours/days/weeks/months.
+type MetricsPeriod string
+
+const (
+	MetricsPeriodHours  MetricsPeriod = "hours"
+	MetricsPeriodDays   MetricsPeriod = "days"
+	MetricsPeriodWeeks  MetricsPeriod = "weeks"
+	MetricsPeriodMonths MetricsPeriod = "months"
+)
+
+// TransactionalMetricsOptions controls the time series window for
+// GetTransactionalMessageMetrics.
+type TransactionalMetricsOptions struct {
+	Period MetricsPeriod
+	Steps  int
+}
+
+// MetricSeries is a set of per-bucket counts, one entry per event kind that
+// applies to the resource being measured.
+type MetricSeries struct {
+	Attempted         []int `json:"attempted,omitempty"`
+	Bounced           []int `json:"bounced,omitempty"`
+	Clicked           []int `json:"clicked,omitempty"`
+	HumanClicked      []int `json:"human_clicked,omitempty"`
+	PrefetchClicked   []int `json:"prefetch_clicked,omitempty"`
+	Converted         []int `json:"converted,omitempty"`
+	Created           []int `json:"created,omitempty"`
+	Deferred          []int `json:"deferred,omitempty"`
+	Delivered         []int `json:"delivered,omitempty"`
+	Drafted           []int `json:"drafted,omitempty"`
+	Failed            []int `json:"failed,omitempty"`
+	Opened            []int `json:"opened,omitempty"`
+	HumanOpened       []int `json:"human_opened,omitempty"`
+	PrefetchOpened    []int `json:"prefetch_opened,omitempty"`
+	Sent              []int `json:"sent,omitempty"`
+	Spammed           []int `json:"spammed,omitempty"`
+	Suppressed        []int `json:"suppressed,omitempty"`
+	Undeliverable     []int `json:"undeliverable,omitempty"`
+	TopicUnsubscribed []int `json:"topic_unsubscribed,omitempty"`
+	Unsubscribed      []int `json:"unsubscribed,omitempty"`
+}
+
+// TransactionalMetricsResponse is the decoded shape of
+// GET /v1/transactional/{id}/metrics.
+type TransactionalMetricsResponse struct {
+	Metric struct {
+		Series MetricSeries `json:"series"`
+	} `json:"metric"`
+}
+
+// GetTransactionalMessageMetrics returns send/delivery/engagement counts
+// over time for a transactional message template.
+// See https://docs.customer.io/api/app/#operation/getTransactionalMessageMetrics
+func (c *APIClient) GetTransactionalMessageMetrics(ctx context.Context, transactionalID string, opts TransactionalMetricsOptions) (*TransactionalMetricsResponse, error) {
+	if transactionalID == "" {
+		return nil, ParamError{Param: "transactionalID"}
+	}
+
+	q := newQuery().setString("period", string(opts.Period)).setInt("steps", opts.Steps)
+	requestPath := formatPath("/v1/transactional/%s/metrics", transactionalID) + q.String()
+
+	var resp TransactionalMetricsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// TransactionalLinkMetricsOptions controls GetTransactionalMessageLinkMetrics.
+type TransactionalLinkMetricsOptions struct {
+	TransactionalMetricsOptions
+	Unique *bool
+}
+
+// LinkMetricSeries is per-bucket click counts for one link.
+type LinkMetricSeries struct {
+	Clicked        []int `json:"clicked,omitempty"`
+	HumanClicked   []int `json:"human_clicked,omitempty"`
+	MachineClicked []int `json:"machine_clicked,omitempty"`
+}
+
+// LinkMetric is one tracked link's click metrics.
+type LinkMetric struct {
+	Link struct {
+		ID   string `json:"id,omitempty"`
+		Href string `json:"href,omitempty"`
+	} `json:"link"`
+	Metric struct {
+		Series LinkMetricSeries `json:"series"`
+	} `json:"metric"`
+}
+
+// TransactionalLinkMetricsResponse is the decoded shape of
+// GET /v1/transactional/{id}/metrics/links.
+type TransactionalLinkMetricsResponse struct {
+	Links []LinkMetric `json:"links"`
+}
+
+// GetTransactionalMessageLinkMetrics returns per-link click metrics for a
+// transactional message template.
+// See https://docs.customer.io/api/app/#operation/getTransactionalMessageLinkMetrics
+func (c *APIClient) GetTransactionalMessageLinkMetrics(ctx context.Context, transactionalID string, opts TransactionalLinkMetricsOptions) (*TransactionalLinkMetricsResponse, error) {
+	if transactionalID == "" {
+		return nil, ParamError{Param: "transactionalID"}
+	}
+
+	q := newQuery().
+		setString("period", string(opts.Period)).
+		setInt("steps", opts.Steps).
+		setBool("unique", opts.Unique)
+	requestPath := formatPath("/v1/transactional/%s/metrics/links", transactionalID) + q.String()
+
+	var resp TransactionalLinkMetricsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// UpdateTransactionalMessageContent updates one content variant by id. data
+// is free-form, matching the App API's own untyped request body.
+// See https://docs.customer.io/api/app/#operation/updateTransactionalMessageContent
+func (c *APIClient) UpdateTransactionalMessageContent(ctx context.Context, transactionalID, contentID string, data map[string]any) (*TransactionalMessageContentResponse, error) {
+	if transactionalID == "" {
+		return nil, ParamError{Param: "transactionalID"}
+	}
+	if contentID == "" {
+		return nil, ParamError{Param: "contentID"}
+	}
+
+	var resp TransactionalMessageContentResponse
+	requestPath := formatPath("/v1/transactional/%s/content/%s", transactionalID, contentID)
+	if err := c.doJSON(ctx, "PUT", requestPath, data, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/transactional_messages.go
+++ b/transactional_messages.go
@@ -155,6 +155,7 @@ type TransactionalDeliveriesOptions struct {
 // GET /v1/transactional/{id}/messages.
 type TransactionalDeliveriesResponse struct {
 	Messages []Message `json:"messages"`
+	Next     string    `json:"next,omitempty"`
 }
 
 // GetTransactionalMessageDeliveries returns the messages sent from a

--- a/transactional_messages_test.go
+++ b/transactional_messages_test.go
@@ -116,7 +116,7 @@ func TestGetTransactionalMessageDeliveries(t *testing.T) {
 	}
 
 	tracked := true
-	api, rec := apiServer(t, 200, map[string]any{"messages": []map[string]any{{"id": "m1", "subject": "hi"}}})
+	api, rec := apiServer(t, 200, map[string]any{"messages": []map[string]any{{"id": "m1", "subject": "hi"}}, "next": "cursor2"})
 	got, err := api.GetTransactionalMessageDeliveries(context.Background(), "1", customerio.TransactionalDeliveriesOptions{
 		Metric:              "opened",
 		StartTS:             100,
@@ -130,6 +130,9 @@ func TestGetTransactionalMessageDeliveries(t *testing.T) {
 	assertAPIRequest(t, rec, "GET", "/v1/transactional/1/messages?end_ts=200&get_tracked_responses=true&limit=10&metric=opened&start_ts=100")
 	if len(got.Messages) != 1 {
 		t.Errorf("unexpected response: %#v", got)
+	}
+	if got.Next != "cursor2" {
+		t.Errorf("unexpected next cursor: %#v", got)
 	}
 }
 

--- a/transactional_messages_test.go
+++ b/transactional_messages_test.go
@@ -1,0 +1,203 @@
+package customerio_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/customerio/go-customerio/v3"
+)
+
+func TestListTransactionalMessages(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"messages": []map[string]any{
+		{"id": 1, "name": "Welcome"},
+	}})
+	got, err := api.ListTransactionalMessages(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/transactional")
+	if len(got.Messages) != 1 || got.Messages[0].Name != "Welcome" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetTransactionalMessage(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetTransactionalMessage(context.Background(), ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "transactionalID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"message": map[string]any{"id": 1, "name": "Welcome"}})
+	got, err := api.GetTransactionalMessage(context.Background(), "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/transactional/1")
+	if got.Message.Name != "Welcome" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetTransactionalMessageContents(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetTransactionalMessageContents(context.Background(), ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "transactionalID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"contents": []map[string]any{
+		{"id": 1, "language": "en", "subject": "hi"},
+	}})
+	got, err := api.GetTransactionalMessageContents(context.Background(), "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/transactional/1/contents")
+	if len(got.Contents) != 1 || got.Contents[0].Subject != "hi" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetTransactionalMessageLanguage(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetTransactionalMessageLanguage(context.Background(), "", "en"); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "transactionalID")
+	}
+	if _, err := api.GetTransactionalMessageLanguage(context.Background(), "1", ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "language")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"content": []map[string]any{{"language": "en", "subject": "hi"}}})
+	got, err := api.GetTransactionalMessageLanguage(context.Background(), "1", "en")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/transactional/1/language/en")
+	if len(got.Content) != 1 || got.Content[0].Language != "en" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestUpdateTransactionalMessageLanguage(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.UpdateTransactionalMessageLanguage(context.Background(), "", "en", nil); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "transactionalID")
+	}
+	if _, err := api.UpdateTransactionalMessageLanguage(context.Background(), "1", "", nil); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "language")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"content": []map[string]any{{"language": "en"}}})
+	data := map[string]any{"subject": "updated"}
+	if _, err := api.UpdateTransactionalMessageLanguage(context.Background(), "1", "en", data); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "PUT", "/v1/transactional/1/language/en")
+	assertJSONEqual(t, rec.body, data)
+}
+
+func TestGetTransactionalMessageDeliveries(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetTransactionalMessageDeliveries(context.Background(), "", customerio.TransactionalDeliveriesOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "transactionalID")
+	}
+
+	tracked := true
+	api, rec := apiServer(t, 200, map[string]any{"messages": []map[string]any{{"id": "m1", "subject": "hi"}}})
+	got, err := api.GetTransactionalMessageDeliveries(context.Background(), "1", customerio.TransactionalDeliveriesOptions{
+		Metric:              "opened",
+		StartTS:             100,
+		EndTS:               200,
+		GetTrackedResponses: &tracked,
+		PaginationOptions:   customerio.PaginationOptions{Limit: 10},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/transactional/1/messages?end_ts=200&get_tracked_responses=true&limit=10&metric=opened&start_ts=100")
+	if len(got.Messages) != 1 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetTransactionalMessageMetrics(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetTransactionalMessageMetrics(context.Background(), "", customerio.TransactionalMetricsOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "transactionalID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"metric": map[string]any{"series": map[string]any{"sent": []int{1, 2, 3}}}})
+	got, err := api.GetTransactionalMessageMetrics(context.Background(), "1", customerio.TransactionalMetricsOptions{
+		Period: customerio.MetricsPeriodDays,
+		Steps:  7,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/transactional/1/metrics?period=days&steps=7")
+	if len(got.Metric.Series.Sent) != 3 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetTransactionalMessageLinkMetrics(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetTransactionalMessageLinkMetrics(context.Background(), "", customerio.TransactionalLinkMetricsOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "transactionalID")
+	}
+
+	unique := true
+	api, rec := apiServer(t, 200, map[string]any{"links": []map[string]any{
+		{"link": map[string]any{"id": "l1", "href": "https://example.com"}, "metric": map[string]any{"series": map[string]any{"clicked": []int{1}}}},
+	}})
+	got, err := api.GetTransactionalMessageLinkMetrics(context.Background(), "1", customerio.TransactionalLinkMetricsOptions{
+		TransactionalMetricsOptions: customerio.TransactionalMetricsOptions{Period: customerio.MetricsPeriodWeeks, Steps: 4},
+		Unique:                      &unique,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/transactional/1/metrics/links?period=weeks&steps=4&unique=true")
+	if len(got.Links) != 1 || got.Links[0].Link.Href != "https://example.com" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestUpdateTransactionalMessageContent(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.UpdateTransactionalMessageContent(context.Background(), "", "c1", nil); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "transactionalID")
+	}
+	if _, err := api.UpdateTransactionalMessageContent(context.Background(), "1", "", nil); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "contentID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"content": []map[string]any{{"id": 5}}})
+	data := map[string]any{"body": "updated"}
+	if _, err := api.UpdateTransactionalMessageContent(context.Background(), "1", "5", data); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "PUT", "/v1/transactional/1/content/5")
+	assertJSONEqual(t, rec.body, data)
+}

--- a/url.go
+++ b/url.go
@@ -3,6 +3,7 @@ package customerio
 import (
 	"fmt"
 	"net/url"
+	"strconv"
 )
 
 // formatPath builds a request path from a printf-style format string, escaping
@@ -19,4 +20,54 @@ func formatPath(format string, args ...any) string {
 		}
 	}
 	return fmt.Sprintf(format, args...)
+}
+
+// queryBuilder accumulates optional query parameters, skipping any left at
+// their zero value — mirroring the App API's own buildQueryString helper
+// (see customerio-node lib/utils.ts), which omits null/undefined/empty
+// values rather than sending them as empty query params.
+type queryBuilder struct {
+	values url.Values
+}
+
+func newQuery() *queryBuilder {
+	return &queryBuilder{values: url.Values{}}
+}
+
+func (q *queryBuilder) setString(key, value string) *queryBuilder {
+	if value != "" {
+		q.values.Set(key, value)
+	}
+	return q
+}
+
+func (q *queryBuilder) setInt(key string, value int) *queryBuilder {
+	if value != 0 {
+		q.values.Set(key, strconv.Itoa(value))
+	}
+	return q
+}
+
+func (q *queryBuilder) setBool(key string, value *bool) *queryBuilder {
+	if value != nil {
+		q.values.Set(key, strconv.FormatBool(*value))
+	}
+	return q
+}
+
+func (q *queryBuilder) setInt64(key string, value int64) *queryBuilder {
+	if value != 0 {
+		q.values.Set(key, strconv.FormatInt(value, 10))
+	}
+	return q
+}
+
+// String renders the accumulated parameters as a "?"-prefixed query string,
+// or "" if no parameter was ever set.
+func (q *queryBuilder) String() string {
+	encoded := q.values.Encode()
+	if encoded == "" {
+		return ""
+	}
+	return "?" + encoded
 }


### PR DESCRIPTION
## Summary

Follow-up to #81 — adds the remaining App API methods around transactional message templates and message lookup that the Node SDK's `APIClient` covers but this client didn't:

- Transactional message management: `ListTransactionalMessages`, `GetTransactionalMessage`, `GetTransactionalMessageContents`, `GetTransactionalMessageLanguage`, `UpdateTransactionalMessageLanguage`, `GetTransactionalMessageDeliveries`, `GetTransactionalMessageMetrics`, `GetTransactionalMessageLinkMetrics`, `UpdateTransactionalMessageContent`.
- Cross-resource messages: `GetMessages`, `GetMessage`, `GetArchivedMessage`.

Extends the shared `Message` type (added in #81 for `GetCustomerMessages`) with fields this group's endpoints also populate (`customer_identifiers`, `parent_action_id`, `trigger_event_id`, `tracked_responses`) — `GET /v1/messages` and `GET /v1/transactional/{id}/messages` return the same object shape as `GET /v1/customers/{id}/messages`, confirmed against the OpenAPI spec's merged field list.

## Notes on shapes

- Request shapes cross-checked against `customerio-node`'s `lib/api.ts`.
- Response shapes cross-checked against the published App API OpenAPI spec. Two free-form `PUT` endpoints (`UpdateTransactionalMessageLanguage`, `UpdateTransactionalMessageContent`) take `map[string]any` since the API itself doesn't constrain the request body shape (matches the Node SDK's own untyped `data` parameter).
- `tracked_responses`' shape isn't documented anywhere, so it's kept as `any` rather than guessed.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `golangci-lint run ./...` (v2.11.3, matching this repo's CI)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large additive surface with remote PUTs that change transactional message content; risk is moderate but mitigated by read-heavy design, client-side validation, and broad tests—no auth or Track API changes.
> 
> **Overview**
> Adds broad **Customer.io App API** coverage to `APIClient`, built on a new shared **`doJSON`** helper, **`queryBuilder`** (omits zero/empty query params), and **`PaginationOptions`**.
> 
> **Customers & search:** `SearchCustomers` with composable **`AudienceFilter`** helpers, email lookup, attributes (single and bulk), per-customer activities/messages/relationships/segments/subscription preferences, and subscription-center tokens.
> 
> **Segments, objects, subscriptions:** App segment CRUD plus membership, counts, and `used_by`; object attributes, relationships, **`FindObjects`** with **`ObjectFilter`** builders, and object types; list subscription topics and channels.
> 
> **Messages & transactional:** Workspace-wide **`GetMessages`** / **`GetMessage`** / **`GetArchivedMessage`**; full transactional template APIs (contents, per-language **PUT** updates, deliveries, metrics, link metrics). Shared **`Message`** gains fields used by cross-resource message endpoints (`customer_identifiers`, `parent_action_id`, `trigger_event_id`, `tracked_responses`).
> 
> **Tests:** `apiServer` / `assertAPIRequest` / `assertJSONEqual` httptest helpers cover the new methods.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5359af3e0268fb815426d7e95698446d27b8327a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->