### PR TITLE
Add App API campaign, broadcast, and newsletter management

### DIFF
--- a/activities.go
+++ b/activities.go
@@ -1,0 +1,58 @@
+package customerio
+
+import "context"
+
+// Activity is an entry from GET /activities or GET /customers/{id}/activities.
+// Data's shape varies by Type: message-delivery activities (sent_email,
+// delivered_email, opened_email, ...) carry {delivery_id, delivered, opened};
+// attribute_change activities carry a map of attribute name to {from, to};
+// event/page/screen activities have no documented shape. It is left as
+// map[string]any rather than modeled per Type for that reason.
+type Activity struct {
+	ID                  string               `json:"id"`
+	Type                string               `json:"type"`
+	Timestamp           int64                `json:"timestamp"`
+	CustomerID          string               `json:"customer_id,omitempty"`
+	CustomerIdentifiers *CustomerIdentifiers `json:"customer_identifiers,omitempty"`
+	DeliveryID          string               `json:"delivery_id,omitempty"`
+	DeliveryType        string               `json:"delivery_type,omitempty"`
+	Name                string               `json:"name,omitempty"`
+	URL                 string               `json:"url,omitempty"`
+	Data                map[string]any       `json:"data,omitempty"`
+}
+
+// ActivitiesResponse is the decoded shape of GET /activities and
+// GET /customers/{id}/activities.
+type ActivitiesResponse struct {
+	Activities []Activity `json:"activities"`
+	Next       string     `json:"next,omitempty"`
+}
+
+// ListActivitiesOptions filters ListActivities.
+type ListActivitiesOptions struct {
+	PaginationOptions
+	Type       string
+	Name       string
+	Deleted    *bool
+	CustomerID string
+	IDType     IdentifierType
+}
+
+// ListActivities returns activity records across all customers, most recent
+// first. See https://docs.customer.io/api/app/#operation/listActivities
+func (c *APIClient) ListActivities(ctx context.Context, opts ListActivitiesOptions) (*ActivitiesResponse, error) {
+	q := opts.PaginationOptions.apply(newQuery()).
+		setString("type", opts.Type).
+		setString("name", opts.Name).
+		setBool("deleted", opts.Deleted).
+		setString("customer_id", opts.CustomerID).
+		setString("id_type", string(opts.IDType))
+
+	requestPath := "/v1/activities" + q.String()
+
+	var resp ActivitiesResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/activities_test.go
+++ b/activities_test.go
@@ -1,0 +1,40 @@
+package customerio_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/customerio/go-customerio/v3"
+)
+
+func TestListActivities(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"activities": []map[string]any{
+		{"id": "act1", "type": "event", "timestamp": 1700000000, "name": "purchased"},
+	}, "next": "cursor2"})
+
+	deleted := false
+	got, err := api.ListActivities(context.Background(), customerio.ListActivitiesOptions{
+		Type:              "event",
+		Name:              "purchased",
+		Deleted:           &deleted,
+		CustomerID:        "1",
+		IDType:            customerio.IdentifierTypeID,
+		PaginationOptions: customerio.PaginationOptions{Limit: 25},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/activities?customer_id=1&deleted=false&id_type=id&limit=25&name=purchased&type=event")
+	if len(got.Activities) != 1 || got.Activities[0].Name != "purchased" || got.Next != "cursor2" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestListActivitiesNoOptions(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"activities": []any{}})
+
+	if _, err := api.ListActivities(context.Background(), customerio.ListActivitiesOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/activities")
+}

--- a/api.go
+++ b/api.go
@@ -2,6 +2,7 @@ package customerio
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 )
 
@@ -42,4 +43,37 @@ func (c *APIClient) doRequest(ctx context.Context, verb, requestPath string, bod
 	return doHTTP(ctx, c.Client, verb, c.URL+requestPath, c.UserAgent, body, func(req *http.Request) {
 		req.Header.Set("Authorization", "Bearer "+c.Key)
 	})
+}
+
+// doJSON executes verb against requestPath, marshaling body as the JSON
+// request payload (nil for none) and unmarshaling the response into out
+// (nil to discard it). A response whose status isn't in okStatuses
+// (defaulting to just http.StatusOK) is returned as a *CustomerIOError.
+func (c *APIClient) doJSON(ctx context.Context, verb, requestPath string, body, out any, okStatuses ...int) error {
+	if len(okStatuses) == 0 {
+		okStatuses = []int{http.StatusOK}
+	}
+
+	respBody, statusCode, err := c.doRequest(ctx, verb, requestPath, body)
+	if err != nil {
+		return err
+	}
+
+	ok := false
+	for _, s := range okStatuses {
+		if statusCode == s {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return &CustomerIOError{status: statusCode, url: c.URL + requestPath, body: respBody}
+	}
+
+	if out != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, out); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/api_helpers_test.go
+++ b/api_helpers_test.go
@@ -1,0 +1,89 @@
+package customerio_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/customerio/go-customerio/v3"
+)
+
+// apiRecord captures the most recent request made through an apiServer.
+type apiRecord struct {
+	method string
+	path   string
+	body   map[string]any
+}
+
+// apiServer creates a per-test HTTP server and APIClient for App API tests.
+// Every request gets statusCode and responseBody (JSON-encoded); the
+// request actually sent is captured into the returned apiRecord so tests
+// can assert against it afterwards.
+func apiServer(t *testing.T, statusCode int, responseBody any) (*customerio.APIClient, *apiRecord) {
+	t.Helper()
+	rec := &apiRecord{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		b, err := io.ReadAll(req.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer func() { _ = req.Body.Close() }()
+
+		rec.method = req.Method
+		rec.path = req.RequestURI
+		rec.body = nil
+		if len(b) > 0 {
+			dec := json.NewDecoder(bytes.NewReader(b))
+			dec.UseNumber()
+			if err := dec.Decode(&rec.body); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
+		w.WriteHeader(statusCode)
+		if responseBody != nil {
+			// errcheck (golangci-lint): explicitly discard return values
+			_ = json.NewEncoder(w).Encode(responseBody)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	api := customerio.NewAPIClient("myKey")
+	api.URL = srv.URL
+	return api, rec
+}
+
+func assertAPIRequest(t *testing.T, rec *apiRecord, method, path string) {
+	t.Helper()
+	if rec.method != method {
+		t.Errorf("expected method %s got %s", method, rec.method)
+	}
+	if rec.path != path {
+		t.Errorf("expected path %s got %s", path, rec.path)
+	}
+}
+
+// assertJSONEqual compares got and want by marshaling both to JSON, rather
+// than reflect.DeepEqual — apiServer decodes request bodies with UseNumber,
+// so a captured numeric field is a json.Number, which never DeepEqual's a
+// float64 literal in a hand-written expectation even when both serialize
+// identically.
+func assertJSONEqual(t *testing.T, got, want any) {
+	t.Helper()
+	gotJSON, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantJSON, err := json.Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(gotJSON, wantJSON) {
+		t.Errorf("body mismatch\nexpected: %s\ngot:      %s", wantJSON, gotJSON)
+	}
+}

--- a/app_segments.go
+++ b/app_segments.go
@@ -1,0 +1,164 @@
+package customerio
+
+import (
+	"context"
+	"net/http"
+)
+
+// Segment is a manual or data-driven audience segment.
+type Segment struct {
+	ID            int      `json:"id"`
+	DeduplicateID string   `json:"deduplicate_id,omitempty"`
+	Name          string   `json:"name"`
+	Description   string   `json:"description,omitempty"`
+	State         string   `json:"state,omitempty"`
+	Progress      *int     `json:"progress,omitempty"`
+	Type          string   `json:"type,omitempty"`
+	Tags          []string `json:"tags,omitempty"`
+	CreatedAt     int64    `json:"created_at,omitempty"`
+	UpdatedAt     int64    `json:"updated_at,omitempty"`
+}
+
+// SegmentResponse wraps a single Segment, as returned by CreateSegment and GetSegment.
+type SegmentResponse struct {
+	Segment Segment `json:"segment"`
+}
+
+// ListSegmentsResponse is the decoded shape of GET /v1/segments.
+type ListSegmentsResponse struct {
+	Segments []Segment `json:"segments"`
+}
+
+// ListSegments returns every segment defined in the workspace.
+// See https://docs.customer.io/api/app/#operation/listSegments
+func (c *APIClient) ListSegments(ctx context.Context) (*ListSegmentsResponse, error) {
+	var resp ListSegmentsResponse
+	if err := c.doJSON(ctx, "GET", "/v1/segments", nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// SegmentInput describes a new manual segment.
+type SegmentInput struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+type createSegmentRequest struct {
+	Segment SegmentInput `json:"segment"`
+}
+
+// CreateSegment creates a new manual segment.
+// See https://docs.customer.io/api/app/#operation/createSegment
+func (c *APIClient) CreateSegment(ctx context.Context, input SegmentInput) (*SegmentResponse, error) {
+	if input.Name == "" {
+		return nil, ParamError{Param: "name"}
+	}
+
+	var resp SegmentResponse
+	if err := c.doJSON(ctx, "POST", "/v1/segments", createSegmentRequest{Segment: input}, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetSegment returns one segment by id.
+// See https://docs.customer.io/api/app/#operation/getSegment
+func (c *APIClient) GetSegment(ctx context.Context, segmentID int) (*SegmentResponse, error) {
+	if segmentID <= 0 {
+		return nil, ParamError{Param: "segmentID"}
+	}
+
+	var resp SegmentResponse
+	if err := c.doJSON(ctx, "GET", formatPath("/v1/segments/%d", segmentID), nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// DeleteSegment deletes a manual segment by id.
+// See https://docs.customer.io/api/app/#operation/deleteSegment
+func (c *APIClient) DeleteSegment(ctx context.Context, segmentID int) error {
+	if segmentID <= 0 {
+		return ParamError{Param: "segmentID"}
+	}
+
+	return c.doJSON(ctx, "DELETE", formatPath("/v1/segments/%d", segmentID), nil, nil, http.StatusOK, http.StatusNoContent)
+}
+
+// SegmentCustomerCountResponse is the decoded shape of
+// GET /v1/segments/{id}/customer_count.
+type SegmentCustomerCountResponse struct {
+	SegmentID int `json:"segment_id"`
+	Count     int `json:"count"`
+}
+
+// GetSegmentCustomerCount returns how many customers currently belong to a segment.
+// See https://docs.customer.io/api/app/#operation/getSegmentCustomerCount
+func (c *APIClient) GetSegmentCustomerCount(ctx context.Context, segmentID int) (*SegmentCustomerCountResponse, error) {
+	if segmentID <= 0 {
+		return nil, ParamError{Param: "segmentID"}
+	}
+
+	var resp SegmentCustomerCountResponse
+	if err := c.doJSON(ctx, "GET", formatPath("/v1/segments/%d/customer_count", segmentID), nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// SegmentMembershipResponse is the decoded shape of
+// GET /v1/segments/{id}/membership. Which of IDs/Identifiers is populated
+// (and which CustomerIdentifiers fields are set) depends on the workspace's
+// identifier configuration.
+type SegmentMembershipResponse struct {
+	SegmentID   int                   `json:"segment_id"`
+	IDs         []string              `json:"ids,omitempty"`
+	Identifiers []CustomerIdentifiers `json:"identifiers,omitempty"`
+	Next        string                `json:"next,omitempty"`
+}
+
+// GetSegmentMembership returns the customers belonging to a segment.
+// See https://docs.customer.io/api/app/#operation/getSegmentMembership
+func (c *APIClient) GetSegmentMembership(ctx context.Context, segmentID int, opts PaginationOptions) (*SegmentMembershipResponse, error) {
+	if segmentID <= 0 {
+		return nil, ParamError{Param: "segmentID"}
+	}
+
+	requestPath := formatPath("/v1/segments/%d/membership", segmentID) + opts.apply(newQuery()).String()
+
+	var resp SegmentMembershipResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// SegmentUsedBy lists the campaigns/newsletters referencing a segment.
+type SegmentUsedBy struct {
+	Campaigns        []int `json:"campaigns,omitempty"`
+	SentNewsletters  []int `json:"sent_newsletters,omitempty"`
+	DraftNewsletters []int `json:"draft_newsletters,omitempty"`
+}
+
+// SegmentUsedByResponse is the decoded shape of GET /v1/segments/{id}/used_by.
+type SegmentUsedByResponse struct {
+	SegmentID int           `json:"segment_id"`
+	UsedBy    SegmentUsedBy `json:"used_by"`
+}
+
+// GetSegmentUsedBy returns what campaigns/newsletters reference a segment —
+// useful to check before deleting it.
+// See https://docs.customer.io/api/app/#operation/getSegmentUsedBy
+func (c *APIClient) GetSegmentUsedBy(ctx context.Context, segmentID int) (*SegmentUsedByResponse, error) {
+	if segmentID <= 0 {
+		return nil, ParamError{Param: "segmentID"}
+	}
+
+	var resp SegmentUsedByResponse
+	if err := c.doJSON(ctx, "GET", formatPath("/v1/segments/%d/used_by", segmentID), nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/app_segments_test.go
+++ b/app_segments_test.go
@@ -1,0 +1,134 @@
+package customerio_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/customerio/go-customerio/v3"
+)
+
+func TestListSegmentsApp(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"segments": []map[string]any{
+		{"id": 1, "name": "VIP", "type": "manual"},
+	}})
+	got, err := api.ListSegments(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/segments")
+	if len(got.Segments) != 1 || got.Segments[0].Name != "VIP" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestCreateSegment(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.CreateSegment(context.Background(), customerio.SegmentInput{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "name")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"segment": map[string]any{"id": 9, "name": "New"}})
+	got, err := api.CreateSegment(context.Background(), customerio.SegmentInput{Name: "New", Description: "desc"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "POST", "/v1/segments")
+	wantBody := map[string]any{"segment": map[string]any{"name": "New", "description": "desc"}}
+	assertJSONEqual(t, rec.body, wantBody)
+	if got.Segment.ID != 9 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetSegmentApp(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetSegment(context.Background(), 0); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "segmentID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"segment": map[string]any{"id": 7, "name": "Gold"}})
+	got, err := api.GetSegment(context.Background(), 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/segments/7")
+	if got.Segment.Name != "Gold" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestDeleteSegment(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if err := api.DeleteSegment(context.Background(), -1); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "segmentID")
+	}
+
+	api, rec := apiServer(t, 204, nil)
+	if err := api.DeleteSegment(context.Background(), 7); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "DELETE", "/v1/segments/7")
+}
+
+func TestGetSegmentCustomerCount(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"segment_id": 7, "count": 42})
+	got, err := api.GetSegmentCustomerCount(context.Background(), 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/segments/7/customer_count")
+	if got.Count != 42 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetSegmentMembership(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{
+		"segment_id":  7,
+		"ids":         []string{"1", "2"},
+		"identifiers": []map[string]any{{"id": "1"}, {"id": "2"}},
+		"next":        "cursor",
+	})
+	got, err := api.GetSegmentMembership(context.Background(), 7, customerio.PaginationOptions{Limit: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/segments/7/membership?limit=2")
+	if len(got.IDs) != 2 || got.Next != "cursor" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetSegmentUsedBy(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{
+		"segment_id": 7,
+		"used_by":    map[string]any{"campaigns": []int{1, 2}, "sent_newsletters": []int{3}},
+	})
+	got, err := api.GetSegmentUsedBy(context.Background(), 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/segments/7/used_by")
+	if len(got.UsedBy.Campaigns) != 2 || len(got.UsedBy.SentNewsletters) != 1 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestAppSegmentsError(t *testing.T) {
+	api, _ := apiServer(t, 404, map[string]any{"errors": []map[string]any{{"detail": "not found"}}})
+
+	_, err := api.GetSegment(context.Background(), 1)
+	cioErr, ok := err.(*customerio.CustomerIOError)
+	if !ok {
+		t.Fatalf("expected *CustomerIOError, got %T", err)
+	}
+	if cioErr.StatusCode() != 404 {
+		t.Errorf("expected status 404, got %d", cioErr.StatusCode())
+	}
+}

--- a/broadcasts.go
+++ b/broadcasts.go
@@ -1,0 +1,305 @@
+package customerio
+
+import "context"
+
+// Broadcast is a one-off (non-recurring) email/push/SMS/etc. send, similar
+// to a Campaign but without a Description or trigger/filter segments.
+type Broadcast struct {
+	ID             int             `json:"id"`
+	DeduplicateID  string          `json:"deduplicate_id,omitempty"`
+	Name           string          `json:"name,omitempty"`
+	Type           string          `json:"type,omitempty"`
+	State          string          `json:"state,omitempty"`
+	Active         bool            `json:"active,omitempty"`
+	Created        int64           `json:"created,omitempty"`
+	Updated        int64           `json:"updated,omitempty"`
+	FirstStarted   int64           `json:"first_started,omitempty"`
+	Tags           []string        `json:"tags,omitempty"`
+	Actions        []ActionSummary `json:"actions,omitempty"`
+	MsgTemplateIDs []int           `json:"msg_template_ids,omitempty"`
+}
+
+// ListBroadcastsResponse is the decoded shape of GET /v1/broadcasts.
+type ListBroadcastsResponse struct {
+	Broadcasts []Broadcast `json:"broadcasts"`
+}
+
+// ListBroadcasts returns every broadcast defined in the workspace.
+// See https://docs.customer.io/api/app/#operation/listBroadcasts
+func (c *APIClient) ListBroadcasts(ctx context.Context) (*ListBroadcastsResponse, error) {
+	var resp ListBroadcastsResponse
+	if err := c.doJSON(ctx, "GET", "/v1/broadcasts", nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// BroadcastResponseWrapper wraps a single Broadcast. Named distinctly from
+// BroadcastResponse (trigger_broadcast.go), which is TriggerBroadcast's
+// {id} acknowledgment and predates this file.
+type BroadcastResponseWrapper struct {
+	Broadcast Broadcast `json:"broadcast"`
+}
+
+// GetBroadcast returns one broadcast by id.
+// See https://docs.customer.io/api/app/#operation/getBroadcast
+func (c *APIClient) GetBroadcast(ctx context.Context, broadcastID string) (*BroadcastResponseWrapper, error) {
+	if broadcastID == "" {
+		return nil, ParamError{Param: "broadcastID"}
+	}
+
+	var resp BroadcastResponseWrapper
+	if err := c.doJSON(ctx, "GET", formatPath("/v1/broadcasts/%s", broadcastID), nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetBroadcastActions returns a broadcast's actions. Unlike
+// GetCampaignActions, this endpoint takes no pagination parameter.
+// See https://docs.customer.io/api/app/#operation/getBroadcastActions
+func (c *APIClient) GetBroadcastActions(ctx context.Context, broadcastID string) (*ActionsResponse, error) {
+	if broadcastID == "" {
+		return nil, ParamError{Param: "broadcastID"}
+	}
+
+	var resp ActionsResponse
+	if err := c.doJSON(ctx, "GET", formatPath("/v1/broadcasts/%s/actions", broadcastID), nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetBroadcastAction returns one broadcast action by id.
+// See https://docs.customer.io/api/app/#operation/getBroadcastAction
+func (c *APIClient) GetBroadcastAction(ctx context.Context, broadcastID, actionID string) (*ActionResponse, error) {
+	if broadcastID == "" {
+		return nil, ParamError{Param: "broadcastID"}
+	}
+	if actionID == "" {
+		return nil, ParamError{Param: "actionID"}
+	}
+
+	requestPath := formatPath("/v1/broadcasts/%s/actions/%s", broadcastID, actionID)
+
+	var resp ActionResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// UpdateBroadcastAction updates a broadcast action. data is free-form.
+// See https://docs.customer.io/api/app/#operation/updateBroadcastAction
+func (c *APIClient) UpdateBroadcastAction(ctx context.Context, broadcastID, actionID string, data map[string]any) (*ActionResponse, error) {
+	if broadcastID == "" {
+		return nil, ParamError{Param: "broadcastID"}
+	}
+	if actionID == "" {
+		return nil, ParamError{Param: "actionID"}
+	}
+
+	requestPath := formatPath("/v1/broadcasts/%s/actions/%s", broadcastID, actionID)
+
+	var resp ActionResponse
+	if err := c.doJSON(ctx, "PUT", requestPath, data, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetBroadcastActionLanguage returns one language variant of a broadcast action.
+// See https://docs.customer.io/api/app/#operation/getBroadcastActionLanguage
+func (c *APIClient) GetBroadcastActionLanguage(ctx context.Context, broadcastID, actionID, language string) (*ActionResponse, error) {
+	if broadcastID == "" {
+		return nil, ParamError{Param: "broadcastID"}
+	}
+	if actionID == "" {
+		return nil, ParamError{Param: "actionID"}
+	}
+	if language == "" {
+		return nil, ParamError{Param: "language"}
+	}
+
+	requestPath := formatPath("/v1/broadcasts/%s/actions/%s/language/%s", broadcastID, actionID, language)
+
+	var resp ActionResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// UpdateBroadcastActionLanguage creates or updates a language variant of a
+// broadcast action. data is free-form.
+// See https://docs.customer.io/api/app/#operation/updateBroadcastActionLanguage
+func (c *APIClient) UpdateBroadcastActionLanguage(ctx context.Context, broadcastID, actionID, language string, data map[string]any) (*ActionResponse, error) {
+	if broadcastID == "" {
+		return nil, ParamError{Param: "broadcastID"}
+	}
+	if actionID == "" {
+		return nil, ParamError{Param: "actionID"}
+	}
+	if language == "" {
+		return nil, ParamError{Param: "language"}
+	}
+
+	requestPath := formatPath("/v1/broadcasts/%s/actions/%s/language/%s", broadcastID, actionID, language)
+
+	var resp ActionResponse
+	if err := c.doJSON(ctx, "PUT", requestPath, data, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetBroadcastActionMetrics returns send/delivery/engagement counts over
+// time for one broadcast action. Unlike campaign action metrics, this
+// endpoint only accepts Period/Steps — no version/res/tz/start/end.
+// See https://docs.customer.io/api/app/#operation/getBroadcastActionMetrics
+func (c *APIClient) GetBroadcastActionMetrics(ctx context.Context, broadcastID, actionID string, opts TransactionalMetricsOptions) (*TransactionalMetricsResponse, error) {
+	if broadcastID == "" {
+		return nil, ParamError{Param: "broadcastID"}
+	}
+	if actionID == "" {
+		return nil, ParamError{Param: "actionID"}
+	}
+
+	q := newQuery().setString("period", string(opts.Period)).setInt("steps", opts.Steps)
+	requestPath := formatPath("/v1/broadcasts/%s/actions/%s/metrics", broadcastID, actionID) + q.String()
+
+	var resp TransactionalMetricsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetBroadcastActionMetricsLinks returns per-link click metrics for one
+// broadcast action.
+// See https://docs.customer.io/api/app/#operation/getBroadcastActionMetricsLinks
+func (c *APIClient) GetBroadcastActionMetricsLinks(ctx context.Context, broadcastID, actionID string, opts TransactionalLinkMetricsOptions) (*TransactionalLinkMetricsResponse, error) {
+	if broadcastID == "" {
+		return nil, ParamError{Param: "broadcastID"}
+	}
+	if actionID == "" {
+		return nil, ParamError{Param: "actionID"}
+	}
+
+	q := newQuery().
+		setString("period", string(opts.Period)).
+		setInt("steps", opts.Steps).
+		setBool("unique", opts.Unique)
+	requestPath := formatPath("/v1/broadcasts/%s/actions/%s/metrics/links", broadcastID, actionID) + q.String()
+
+	var resp TransactionalLinkMetricsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// BroadcastMetricsOptions controls GetBroadcastMetrics.
+type BroadcastMetricsOptions struct {
+	TransactionalMetricsOptions
+	Type MetricType
+}
+
+// GetBroadcastMetrics returns send/delivery/engagement counts over time for
+// a whole broadcast.
+// See https://docs.customer.io/api/app/#operation/getBroadcastMetrics
+func (c *APIClient) GetBroadcastMetrics(ctx context.Context, broadcastID string, opts BroadcastMetricsOptions) (*TransactionalMetricsResponse, error) {
+	if broadcastID == "" {
+		return nil, ParamError{Param: "broadcastID"}
+	}
+
+	q := newQuery().
+		setString("period", string(opts.Period)).
+		setInt("steps", opts.Steps).
+		setString("type", string(opts.Type))
+	requestPath := formatPath("/v1/broadcasts/%s/metrics", broadcastID) + q.String()
+
+	var resp TransactionalMetricsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetBroadcastMetricsLinks returns per-link click metrics for a whole broadcast.
+// See https://docs.customer.io/api/app/#operation/getBroadcastMetricsLinks
+func (c *APIClient) GetBroadcastMetricsLinks(ctx context.Context, broadcastID string, opts TransactionalLinkMetricsOptions) (*TransactionalLinkMetricsResponse, error) {
+	if broadcastID == "" {
+		return nil, ParamError{Param: "broadcastID"}
+	}
+
+	q := newQuery().
+		setString("period", string(opts.Period)).
+		setInt("steps", opts.Steps).
+		setBool("unique", opts.Unique)
+	requestPath := formatPath("/v1/broadcasts/%s/metrics/links", broadcastID) + q.String()
+
+	var resp TransactionalLinkMetricsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// BroadcastMessagesOptions filters GetBroadcastMessages.
+type BroadcastMessagesOptions struct {
+	PaginationOptions
+	Metric              string
+	Type                MetricType
+	StartTS             int64
+	EndTS               int64
+	GetTrackedResponses *bool
+}
+
+// GetBroadcastMessages returns messages sent from a broadcast.
+// See https://docs.customer.io/api/app/#operation/getBroadcastMessages
+func (c *APIClient) GetBroadcastMessages(ctx context.Context, broadcastID string, opts BroadcastMessagesOptions) (*MessagesResponse, error) {
+	if broadcastID == "" {
+		return nil, ParamError{Param: "broadcastID"}
+	}
+
+	q := opts.PaginationOptions.apply(newQuery()).
+		setString("metric", opts.Metric).
+		setString("type", string(opts.Type)).
+		setInt64("start_ts", opts.StartTS).
+		setInt64("end_ts", opts.EndTS).
+		setBool("get_tracked_responses", opts.GetTrackedResponses)
+	requestPath := formatPath("/v1/broadcasts/%s/messages", broadcastID) + q.String()
+
+	var resp MessagesResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// BroadcastTriggersResponse is the decoded shape of GET /v1/broadcasts/{id}/triggers.
+// The per-entry shape isn't independently documented; it's inferred to
+// match GetBroadcastTriggerStatus's object, by convention with every other
+// list endpoint in this API returning the same shape as its single-item GET.
+type BroadcastTriggersResponse struct {
+	Triggers []BroadcastTriggerStatus `json:"triggers"`
+}
+
+// GetBroadcastTriggers lists every trigger fired for a broadcast. To check
+// one trigger's status or errors, see GetBroadcastTriggerStatus and
+// GetBroadcastTriggerErrors (trigger_broadcast.go) — those two address the
+// same triggers under /v1/campaigns/{broadcastID}/triggers/{triggerID}, a
+// real (if surprising) App API path inconsistency, not a typo here.
+// See https://docs.customer.io/api/app/#operation/getBroadcastTriggers
+func (c *APIClient) GetBroadcastTriggers(ctx context.Context, broadcastID string) (*BroadcastTriggersResponse, error) {
+	if broadcastID == "" {
+		return nil, ParamError{Param: "broadcastID"}
+	}
+
+	var resp BroadcastTriggersResponse
+	if err := c.doJSON(ctx, "GET", formatPath("/v1/broadcasts/%s/triggers", broadcastID), nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/broadcasts_test.go
+++ b/broadcasts_test.go
@@ -1,0 +1,185 @@
+package customerio_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/customerio/go-customerio/v3"
+)
+
+func TestListBroadcasts(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"broadcasts": []map[string]any{{"id": 1, "name": "Flash Sale"}}})
+	got, err := api.ListBroadcasts(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/broadcasts")
+	if len(got.Broadcasts) != 1 || got.Broadcasts[0].Name != "Flash Sale" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetBroadcast(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetBroadcast(context.Background(), ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "broadcastID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"broadcast": map[string]any{"id": 1}})
+	if _, err := api.GetBroadcast(context.Background(), "1"); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/broadcasts/1")
+}
+
+func TestGetBroadcastActions(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetBroadcastActions(context.Background(), ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "broadcastID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"actions": []map[string]any{{"id": 5}}})
+	got, err := api.GetBroadcastActions(context.Background(), "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/broadcasts/1/actions")
+	if len(got.Actions) != 1 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestBroadcastAction(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetBroadcastAction(context.Background(), "", "5"); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "broadcastID")
+	}
+	if _, err := api.GetBroadcastAction(context.Background(), "1", ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "actionID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"action": map[string]any{"id": 5}})
+	if _, err := api.GetBroadcastAction(context.Background(), "1", "5"); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/broadcasts/1/actions/5")
+
+	data := map[string]any{"subject": "hi"}
+	if _, err := api.UpdateBroadcastAction(context.Background(), "1", "5", data); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "PUT", "/v1/broadcasts/1/actions/5")
+	assertJSONEqual(t, rec.body, data)
+}
+
+func TestBroadcastActionLanguage(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"action": map[string]any{"id": 5, "language": "en"}})
+	if _, err := api.GetBroadcastActionLanguage(context.Background(), "1", "5", "en"); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/broadcasts/1/actions/5/language/en")
+
+	data := map[string]any{"subject": "hi"}
+	if _, err := api.UpdateBroadcastActionLanguage(context.Background(), "1", "5", "en", data); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "PUT", "/v1/broadcasts/1/actions/5/language/en")
+	assertJSONEqual(t, rec.body, data)
+
+	if _, err := api.GetBroadcastActionLanguage(context.Background(), "1", "5", ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "language")
+	}
+}
+
+func TestGetBroadcastActionMetrics(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"metric": map[string]any{"series": map[string]any{}}})
+	if _, err := api.GetBroadcastActionMetrics(context.Background(), "1", "5", customerio.TransactionalMetricsOptions{Period: customerio.MetricsPeriodHours, Steps: 6}); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/broadcasts/1/actions/5/metrics?period=hours&steps=6")
+
+	if _, err := api.GetBroadcastActionMetrics(context.Background(), "", "5", customerio.TransactionalMetricsOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "broadcastID")
+	}
+}
+
+func TestGetBroadcastActionMetricsLinks(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"links": []any{}})
+	if _, err := api.GetBroadcastActionMetricsLinks(context.Background(), "1", "5", customerio.TransactionalLinkMetricsOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/broadcasts/1/actions/5/metrics/links")
+}
+
+func TestGetBroadcastMetrics(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetBroadcastMetrics(context.Background(), "", customerio.BroadcastMetricsOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "broadcastID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"metric": map[string]any{"series": map[string]any{}}})
+	if _, err := api.GetBroadcastMetrics(context.Background(), "1", customerio.BroadcastMetricsOptions{Type: customerio.MetricTypePush}); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/broadcasts/1/metrics?type=push")
+}
+
+func TestGetBroadcastMetricsLinks(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"links": []any{}})
+	if _, err := api.GetBroadcastMetricsLinks(context.Background(), "1", customerio.TransactionalLinkMetricsOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/broadcasts/1/metrics/links")
+}
+
+func TestGetBroadcastMessages(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetBroadcastMessages(context.Background(), "", customerio.BroadcastMessagesOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "broadcastID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"messages": []map[string]any{{"id": "m1"}}})
+	got, err := api.GetBroadcastMessages(context.Background(), "1", customerio.BroadcastMessagesOptions{Metric: "opened"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/broadcasts/1/messages?metric=opened")
+	if len(got.Messages) != 1 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetBroadcastTriggers(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetBroadcastTriggers(context.Background(), ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "broadcastID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"triggers": []map[string]any{{"id": 9, "broadcast_id": 1}}})
+	got, err := api.GetBroadcastTriggers(context.Background(), "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/broadcasts/1/triggers")
+	if len(got.Triggers) != 1 || got.Triggers[0].ID != 9 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}

--- a/campaigns.go
+++ b/campaigns.go
@@ -1,0 +1,407 @@
+package customerio
+
+import "context"
+
+// ActionSummary is a campaign or broadcast's abbreviated reference to one
+// of its actions, as embedded in the Campaign/Broadcast object's Actions list.
+type ActionSummary struct {
+	Type string `json:"type,omitempty"`
+	ID   int    `json:"id,omitempty"`
+}
+
+// Campaign is an email/push/SMS/etc. journey triggered by a segment or event.
+type Campaign struct {
+	ID                int             `json:"id"`
+	DeduplicateID     string          `json:"deduplicate_id,omitempty"`
+	Name              string          `json:"name,omitempty"`
+	Description       string          `json:"description,omitempty"`
+	Type              string          `json:"type,omitempty"`
+	State             string          `json:"state,omitempty"`
+	Active            bool            `json:"active,omitempty"`
+	Created           int64           `json:"created,omitempty"`
+	Updated           int64           `json:"updated,omitempty"`
+	FirstStarted      int64           `json:"first_started,omitempty"`
+	Tags              []string        `json:"tags,omitempty"`
+	TriggerSegmentIDs []int           `json:"trigger_segment_ids,omitempty"`
+	FilterSegmentIDs  []int           `json:"filter_segment_ids,omitempty"`
+	Actions           []ActionSummary `json:"actions,omitempty"`
+}
+
+// ListCampaignsResponse is the decoded shape of GET /v1/campaigns.
+type ListCampaignsResponse struct {
+	Campaigns []Campaign `json:"campaigns"`
+}
+
+// ListCampaigns returns every campaign defined in the workspace.
+// See https://docs.customer.io/api/app/#operation/listCampaigns
+func (c *APIClient) ListCampaigns(ctx context.Context) (*ListCampaignsResponse, error) {
+	var resp ListCampaignsResponse
+	if err := c.doJSON(ctx, "GET", "/v1/campaigns", nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// CampaignResponse wraps a single Campaign.
+type CampaignResponse struct {
+	Campaign Campaign `json:"campaign"`
+}
+
+// GetCampaign returns one campaign by id.
+// See https://docs.customer.io/api/app/#operation/getCampaign
+func (c *APIClient) GetCampaign(ctx context.Context, campaignID string) (*CampaignResponse, error) {
+	if campaignID == "" {
+		return nil, ParamError{Param: "campaignID"}
+	}
+
+	var resp CampaignResponse
+	if err := c.doJSON(ctx, "GET", formatPath("/v1/campaigns/%s", campaignID), nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// Action is one step (email/push/SMS/webhook/...) in a campaign or
+// broadcast. BroadcastID names the parent campaign or broadcast id despite
+// the field name — that's the wire field name for both resource types.
+type Action struct {
+	ID            int    `json:"id"`
+	BroadcastID   int    `json:"broadcast_id,omitempty"`
+	DeduplicateID string `json:"deduplicate_id,omitempty"`
+	Name          string `json:"name,omitempty"`
+	Layout        string `json:"layout,omitempty"`
+	Created       int64  `json:"created,omitempty"`
+	Updated       int64  `json:"updated,omitempty"`
+	Body          string `json:"body,omitempty"`
+	Type          string `json:"type,omitempty"`
+	SendingState  string `json:"sending_state,omitempty"`
+	Language      string `json:"language,omitempty"`
+	From          string `json:"from,omitempty"`
+	FromID        *int   `json:"from_id,omitempty"`
+	ReplyTo       string `json:"reply_to,omitempty"`
+	ReplyToID     *int   `json:"reply_to_id,omitempty"`
+	Subject       string `json:"subject,omitempty"`
+	Recipient     string `json:"recipient,omitempty"`
+	CC            string `json:"cc,omitempty"`
+	BCC           string `json:"bcc,omitempty"`
+}
+
+// ActionResponse wraps a single Action.
+type ActionResponse struct {
+	Action Action `json:"action"`
+}
+
+// ActionsResponse is the decoded shape of an actions-list endpoint.
+type ActionsResponse struct {
+	Actions []Action `json:"actions"`
+}
+
+// GetCampaignActions returns a campaign's actions. start is an opaque
+// pagination cursor from a previous call, or "" for the first page.
+// See https://docs.customer.io/api/app/#operation/getCampaignActions
+func (c *APIClient) GetCampaignActions(ctx context.Context, campaignID, start string) (*ActionsResponse, error) {
+	if campaignID == "" {
+		return nil, ParamError{Param: "campaignID"}
+	}
+
+	requestPath := formatPath("/v1/campaigns/%s/actions", campaignID) + newQuery().setString("start", start).String()
+
+	var resp ActionsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetCampaignAction returns one campaign action by id.
+// See https://docs.customer.io/api/app/#operation/getCampaignAction
+func (c *APIClient) GetCampaignAction(ctx context.Context, campaignID, actionID string) (*ActionResponse, error) {
+	if campaignID == "" {
+		return nil, ParamError{Param: "campaignID"}
+	}
+	if actionID == "" {
+		return nil, ParamError{Param: "actionID"}
+	}
+
+	requestPath := formatPath("/v1/campaigns/%s/actions/%s", campaignID, actionID)
+
+	var resp ActionResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// UpdateCampaignAction updates a campaign action. data is free-form,
+// matching the App API's own untyped request body for this endpoint.
+// See https://docs.customer.io/api/app/#operation/updateCampaignAction
+func (c *APIClient) UpdateCampaignAction(ctx context.Context, campaignID, actionID string, data map[string]any) (*ActionResponse, error) {
+	if campaignID == "" {
+		return nil, ParamError{Param: "campaignID"}
+	}
+	if actionID == "" {
+		return nil, ParamError{Param: "actionID"}
+	}
+
+	requestPath := formatPath("/v1/campaigns/%s/actions/%s", campaignID, actionID)
+
+	var resp ActionResponse
+	if err := c.doJSON(ctx, "PUT", requestPath, data, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetCampaignActionLanguage returns one language variant of a campaign action.
+// See https://docs.customer.io/api/app/#operation/getCampaignActionLanguage
+func (c *APIClient) GetCampaignActionLanguage(ctx context.Context, campaignID, actionID, language string) (*ActionResponse, error) {
+	if campaignID == "" {
+		return nil, ParamError{Param: "campaignID"}
+	}
+	if actionID == "" {
+		return nil, ParamError{Param: "actionID"}
+	}
+	if language == "" {
+		return nil, ParamError{Param: "language"}
+	}
+
+	requestPath := formatPath("/v1/campaigns/%s/actions/%s/language/%s", campaignID, actionID, language)
+
+	var resp ActionResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// UpdateCampaignActionLanguage creates or updates a language variant of a
+// campaign action. data is free-form.
+// See https://docs.customer.io/api/app/#operation/updateCampaignActionLanguage
+func (c *APIClient) UpdateCampaignActionLanguage(ctx context.Context, campaignID, actionID, language string, data map[string]any) (*ActionResponse, error) {
+	if campaignID == "" {
+		return nil, ParamError{Param: "campaignID"}
+	}
+	if actionID == "" {
+		return nil, ParamError{Param: "actionID"}
+	}
+	if language == "" {
+		return nil, ParamError{Param: "language"}
+	}
+
+	requestPath := formatPath("/v1/campaigns/%s/actions/%s/language/%s", campaignID, actionID, language)
+
+	var resp ActionResponse
+	if err := c.doJSON(ctx, "PUT", requestPath, data, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// CampaignActionMetricsOptions controls GetCampaignActionMetrics.
+type CampaignActionMetricsOptions struct {
+	TransactionalMetricsOptions
+	Version CampaignMetricsVersion
+	Res     MetricResolution
+	TZ      string
+	Start   int64
+	End     int64
+}
+
+// GetCampaignActionMetrics returns send/delivery/engagement counts over
+// time for one campaign action.
+// See https://docs.customer.io/api/app/#operation/getCampaignActionMetrics
+func (c *APIClient) GetCampaignActionMetrics(ctx context.Context, campaignID, actionID string, opts CampaignActionMetricsOptions) (*TransactionalMetricsResponse, error) {
+	if campaignID == "" {
+		return nil, ParamError{Param: "campaignID"}
+	}
+	if actionID == "" {
+		return nil, ParamError{Param: "actionID"}
+	}
+
+	q := newQuery().
+		setString("version", string(opts.Version)).
+		setString("res", string(opts.Res)).
+		setString("tz", opts.TZ).
+		setInt64("start", opts.Start).
+		setInt64("end", opts.End).
+		setString("period", string(opts.Period)).
+		setInt("steps", opts.Steps)
+	requestPath := formatPath("/v1/campaigns/%s/actions/%s/metrics", campaignID, actionID) + q.String()
+
+	var resp TransactionalMetricsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetCampaignActionMetricsLinks returns per-link click metrics for one
+// campaign action.
+// See https://docs.customer.io/api/app/#operation/getCampaignActionMetricsLinks
+func (c *APIClient) GetCampaignActionMetricsLinks(ctx context.Context, campaignID, actionID string, opts TransactionalLinkMetricsOptions) (*TransactionalLinkMetricsResponse, error) {
+	if campaignID == "" {
+		return nil, ParamError{Param: "campaignID"}
+	}
+	if actionID == "" {
+		return nil, ParamError{Param: "actionID"}
+	}
+
+	q := newQuery().
+		setString("period", string(opts.Period)).
+		setInt("steps", opts.Steps).
+		setBool("unique", opts.Unique)
+	requestPath := formatPath("/v1/campaigns/%s/actions/%s/metrics/links", campaignID, actionID) + q.String()
+
+	var resp TransactionalLinkMetricsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// CampaignMetricsOptions controls GetCampaignMetrics.
+type CampaignMetricsOptions struct {
+	TransactionalMetricsOptions
+	Version CampaignMetricsVersion
+	Type    MetricType
+	Res     MetricResolution
+	TZ      string
+	Start   int64
+	End     int64
+}
+
+// GetCampaignMetrics returns send/delivery/engagement counts over time for
+// a whole campaign.
+// See https://docs.customer.io/api/app/#operation/getCampaignMetrics
+func (c *APIClient) GetCampaignMetrics(ctx context.Context, campaignID string, opts CampaignMetricsOptions) (*TransactionalMetricsResponse, error) {
+	if campaignID == "" {
+		return nil, ParamError{Param: "campaignID"}
+	}
+
+	q := newQuery().
+		setString("version", string(opts.Version)).
+		setString("type", string(opts.Type)).
+		setString("res", string(opts.Res)).
+		setString("tz", opts.TZ).
+		setInt64("start", opts.Start).
+		setInt64("end", opts.End).
+		setString("period", string(opts.Period)).
+		setInt("steps", opts.Steps)
+	requestPath := formatPath("/v1/campaigns/%s/metrics", campaignID) + q.String()
+
+	var resp TransactionalMetricsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetCampaignMetricsLinks returns per-link click metrics for a whole campaign.
+// See https://docs.customer.io/api/app/#operation/getCampaignMetricsLinks
+func (c *APIClient) GetCampaignMetricsLinks(ctx context.Context, campaignID string, opts TransactionalLinkMetricsOptions) (*TransactionalLinkMetricsResponse, error) {
+	if campaignID == "" {
+		return nil, ParamError{Param: "campaignID"}
+	}
+
+	q := newQuery().
+		setString("period", string(opts.Period)).
+		setInt("steps", opts.Steps).
+		setBool("unique", opts.Unique)
+	requestPath := formatPath("/v1/campaigns/%s/metrics/links", campaignID) + q.String()
+
+	var resp TransactionalLinkMetricsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// JourneyMetricsOptions controls GetCampaignJourneyMetrics. Unlike other
+// metrics endpoints, Start, End, and Resolution are all required.
+type JourneyMetricsOptions struct {
+	Start      int64
+	End        int64
+	Resolution MetricResolution
+}
+
+// JourneyMetricSeries is a funnel report of how customers moved through a
+// campaign, one entry per stage.
+type JourneyMetricSeries struct {
+	Started        []int `json:"started,omitempty"`
+	Activated      []int `json:"activated,omitempty"`
+	ExitedEarly    []int `json:"exited_early,omitempty"`
+	Finished       []int `json:"finished,omitempty"`
+	Converted      []int `json:"converted,omitempty"`
+	NeverActivated []int `json:"never_activated,omitempty"`
+	Messaged       []int `json:"messaged,omitempty"`
+}
+
+// JourneyMetricsResponse is the decoded shape of GET /v1/campaigns/{id}/journey_metrics.
+type JourneyMetricsResponse struct {
+	JourneyMetric JourneyMetricSeries `json:"journey_metric"`
+}
+
+// GetCampaignJourneyMetrics returns a funnel report of how customers moved
+// through a campaign (started/activated/exited_early/finished/converted/
+// never_activated/messaged), bucketed by opts.Resolution.
+// See https://docs.customer.io/api/app/#operation/getCampaignJourneyMetrics
+func (c *APIClient) GetCampaignJourneyMetrics(ctx context.Context, campaignID string, opts JourneyMetricsOptions) (*JourneyMetricsResponse, error) {
+	if campaignID == "" {
+		return nil, ParamError{Param: "campaignID"}
+	}
+	if opts.Start == 0 {
+		return nil, ParamError{Param: "start"}
+	}
+	if opts.End == 0 {
+		return nil, ParamError{Param: "end"}
+	}
+	if opts.Resolution == "" {
+		return nil, ParamError{Param: "resolution"}
+	}
+
+	// Wire query param is "resolution"; the option field is named Resolution
+	// to match (the Node SDK's option field is the abbreviated "res", but the
+	// query param it sends is spelled out — kept explicit here instead).
+	q := newQuery().setInt64("start", opts.Start).setInt64("end", opts.End).setString("resolution", string(opts.Resolution))
+	requestPath := formatPath("/v1/campaigns/%s/journey_metrics", campaignID) + q.String()
+
+	var resp JourneyMetricsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// CampaignMessagesOptions filters GetCampaignMessages.
+type CampaignMessagesOptions struct {
+	PaginationOptions
+	Type                MetricType
+	Metric              string
+	Drafts              *bool
+	StartTS             int64
+	EndTS               int64
+	GetTrackedResponses *bool
+}
+
+// GetCampaignMessages returns messages sent from a campaign.
+// See https://docs.customer.io/api/app/#operation/getCampaignMessages
+func (c *APIClient) GetCampaignMessages(ctx context.Context, campaignID string, opts CampaignMessagesOptions) (*MessagesResponse, error) {
+	if campaignID == "" {
+		return nil, ParamError{Param: "campaignID"}
+	}
+
+	q := opts.PaginationOptions.apply(newQuery()).
+		setString("type", string(opts.Type)).
+		setString("metric", opts.Metric).
+		setBool("drafts", opts.Drafts).
+		setInt64("start_ts", opts.StartTS).
+		setInt64("end_ts", opts.EndTS).
+		setBool("get_tracked_responses", opts.GetTrackedResponses)
+	requestPath := formatPath("/v1/campaigns/%s/messages", campaignID) + q.String()
+
+	var resp MessagesResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/campaigns.go
+++ b/campaigns.go
@@ -94,6 +94,7 @@ type ActionResponse struct {
 // ActionsResponse is the decoded shape of an actions-list endpoint.
 type ActionsResponse struct {
 	Actions []Action `json:"actions"`
+	Next    string   `json:"next,omitempty"`
 }
 
 // GetCampaignActions returns a campaign's actions. start is an opaque

--- a/campaigns_test.go
+++ b/campaigns_test.go
@@ -1,0 +1,263 @@
+package customerio_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/customerio/go-customerio/v3"
+)
+
+func TestListCampaigns(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"campaigns": []map[string]any{{"id": 1, "name": "Onboarding"}}})
+	got, err := api.ListCampaigns(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/campaigns")
+	if len(got.Campaigns) != 1 || got.Campaigns[0].Name != "Onboarding" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetCampaign(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetCampaign(context.Background(), ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "campaignID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"campaign": map[string]any{"id": 1, "state": "running"}})
+	got, err := api.GetCampaign(context.Background(), "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/campaigns/1")
+	if got.Campaign.State != "running" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetCampaignActions(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetCampaignActions(context.Background(), "", ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "campaignID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"actions": []map[string]any{{"id": 5, "type": "email"}}})
+	got, err := api.GetCampaignActions(context.Background(), "1", "cursor1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/campaigns/1/actions?start=cursor1")
+	if len(got.Actions) != 1 || got.Actions[0].Type != "email" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetCampaignAction(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetCampaignAction(context.Background(), "", "5"); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "campaignID")
+	}
+	if _, err := api.GetCampaignAction(context.Background(), "1", ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "actionID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"action": map[string]any{"id": 5}})
+	if _, err := api.GetCampaignAction(context.Background(), "1", "5"); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/campaigns/1/actions/5")
+}
+
+func TestUpdateCampaignAction(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.UpdateCampaignAction(context.Background(), "", "5", nil); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "campaignID")
+	}
+	if _, err := api.UpdateCampaignAction(context.Background(), "1", "", nil); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "actionID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"action": map[string]any{"id": 5}})
+	data := map[string]any{"subject": "new subject"}
+	if _, err := api.UpdateCampaignAction(context.Background(), "1", "5", data); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "PUT", "/v1/campaigns/1/actions/5")
+	assertJSONEqual(t, rec.body, data)
+}
+
+func TestCampaignActionLanguage(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetCampaignActionLanguage(context.Background(), "", "5", "en"); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "campaignID")
+	}
+	if _, err := api.GetCampaignActionLanguage(context.Background(), "1", "", "en"); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "actionID")
+	}
+	if _, err := api.GetCampaignActionLanguage(context.Background(), "1", "5", ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "language")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"action": map[string]any{"id": 5, "language": "en"}})
+	if _, err := api.GetCampaignActionLanguage(context.Background(), "1", "5", "en"); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/campaigns/1/actions/5/language/en")
+
+	data := map[string]any{"subject": "hi"}
+	if _, err := api.UpdateCampaignActionLanguage(context.Background(), "1", "5", "en", data); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "PUT", "/v1/campaigns/1/actions/5/language/en")
+	assertJSONEqual(t, rec.body, data)
+}
+
+func TestGetCampaignActionMetrics(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetCampaignActionMetrics(context.Background(), "", "5", customerio.CampaignActionMetricsOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "campaignID")
+	}
+	if _, err := api.GetCampaignActionMetrics(context.Background(), "1", "", customerio.CampaignActionMetricsOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "actionID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"metric": map[string]any{"series": map[string]any{"sent": []int{1}}}})
+	got, err := api.GetCampaignActionMetrics(context.Background(), "1", "5", customerio.CampaignActionMetricsOptions{
+		Version:                     customerio.CampaignMetricsVersion2,
+		Res:                         "days",
+		TZ:                          "UTC",
+		Start:                       100,
+		End:                         200,
+		TransactionalMetricsOptions: customerio.TransactionalMetricsOptions{Period: customerio.MetricsPeriodDays, Steps: 3},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/campaigns/1/actions/5/metrics?end=200&period=days&res=days&start=100&steps=3&tz=UTC&version=2")
+	if len(got.Metric.Series.Sent) != 1 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetCampaignActionMetricsLinks(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"links": []map[string]any{}})
+	unique := true
+	if _, err := api.GetCampaignActionMetricsLinks(context.Background(), "1", "5", customerio.TransactionalLinkMetricsOptions{
+		TransactionalMetricsOptions: customerio.TransactionalMetricsOptions{Period: customerio.MetricsPeriodWeeks, Steps: 2},
+		Unique:                      &unique,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/campaigns/1/actions/5/metrics/links?period=weeks&steps=2&unique=true")
+}
+
+func TestGetCampaignMetrics(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetCampaignMetrics(context.Background(), "", customerio.CampaignMetricsOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "campaignID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"metric": map[string]any{"series": map[string]any{}}})
+	if _, err := api.GetCampaignMetrics(context.Background(), "1", customerio.CampaignMetricsOptions{Type: customerio.MetricTypeEmail}); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/campaigns/1/metrics?type=email")
+}
+
+func TestGetCampaignMetricsLinks(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetCampaignMetricsLinks(context.Background(), "", customerio.TransactionalLinkMetricsOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "campaignID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"links": []any{}})
+	if _, err := api.GetCampaignMetricsLinks(context.Background(), "1", customerio.TransactionalLinkMetricsOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/campaigns/1/metrics/links")
+}
+
+func TestGetCampaignJourneyMetrics(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetCampaignJourneyMetrics(context.Background(), "", customerio.JourneyMetricsOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "campaignID")
+	}
+	if _, err := api.GetCampaignJourneyMetrics(context.Background(), "1", customerio.JourneyMetricsOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "start")
+	}
+	if _, err := api.GetCampaignJourneyMetrics(context.Background(), "1", customerio.JourneyMetricsOptions{Start: 100}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "end")
+	}
+	if _, err := api.GetCampaignJourneyMetrics(context.Background(), "1", customerio.JourneyMetricsOptions{Start: 100, End: 200}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "resolution")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"journey_metric": map[string]any{"started": []int{1, 2}}})
+	got, err := api.GetCampaignJourneyMetrics(context.Background(), "1", customerio.JourneyMetricsOptions{Start: 100, End: 200, Resolution: "days"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/campaigns/1/journey_metrics?end=200&resolution=days&start=100")
+	if len(got.JourneyMetric.Started) != 2 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetCampaignMessages(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetCampaignMessages(context.Background(), "", customerio.CampaignMessagesOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "campaignID")
+	}
+
+	drafts := true
+	api, rec := apiServer(t, 200, map[string]any{"messages": []map[string]any{{"id": "m1"}}})
+	got, err := api.GetCampaignMessages(context.Background(), "1", customerio.CampaignMessagesOptions{
+		Type:              customerio.MetricTypeEmail,
+		Drafts:            &drafts,
+		PaginationOptions: customerio.PaginationOptions{Limit: 10},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/campaigns/1/messages?drafts=true&limit=10&type=email")
+	if len(got.Messages) != 1 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}

--- a/customers.go
+++ b/customers.go
@@ -1,0 +1,379 @@
+package customerio
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// CustomerIdentifiers identifies a customer by all three identifier kinds
+// Customer.io tracks. It appears in search/list results so callers can look
+// the customer up by whichever identifier they have on hand.
+type CustomerIdentifiers struct {
+	ID    string `json:"id,omitempty"`
+	Email string `json:"email,omitempty"`
+	CioID string `json:"cio_id,omitempty"`
+}
+
+// searchCustomersRequest is the POST /v1/customers body.
+type searchCustomersRequest struct {
+	Filter AudienceFilter `json:"filter"`
+}
+
+// SearchCustomersResponse is the decoded shape of POST /v1/customers.
+type SearchCustomersResponse struct {
+	Identifiers []CustomerIdentifiers `json:"identifiers"`
+	IDs         []string              `json:"ids"`
+	Next        string                `json:"next,omitempty"`
+}
+
+// SearchCustomers finds customers matching filter (built with FilterBySegment,
+// FilterByAttribute, and the FilterAnd/FilterOr/FilterNot combinators).
+// See https://docs.customer.io/api/app/#operation/searchCustomers
+func (c *APIClient) SearchCustomers(ctx context.Context, filter AudienceFilter, opts PaginationOptions) (*SearchCustomersResponse, error) {
+	requestPath := "/v1/customers" + opts.apply(newQuery()).String()
+
+	var resp SearchCustomersResponse
+	if err := c.doJSON(ctx, "POST", requestPath, searchCustomersRequest{Filter: filter}, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetCustomersByEmailResponse is the decoded shape of GET /v1/customers?email=.
+type GetCustomersByEmailResponse struct {
+	Results []CustomerIdentifiers `json:"results"`
+}
+
+// GetCustomersByEmail looks up every customer profile with the given email —
+// Customer.io allows duplicate emails across profiles, so this can return
+// more than one result. See https://docs.customer.io/api/app/#operation/getCustomersByEmail
+func (c *APIClient) GetCustomersByEmail(ctx context.Context, email string) (*GetCustomersByEmailResponse, error) {
+	if email == "" {
+		return nil, ParamError{Param: "email"}
+	}
+
+	requestPath := "/v1/customers" + newQuery().setString("email", email).String()
+
+	var resp GetCustomersByEmailResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// CustomerDevice is a push notification device registered to a customer.
+type CustomerDevice struct {
+	ID         string         `json:"id"`
+	LastUsed   int64          `json:"last_used,omitempty"`
+	Platform   string         `json:"platform"`
+	Attributes map[string]any `json:"attributes,omitempty"`
+}
+
+// Customer is a customer profile as returned by the attributes endpoints.
+// Attributes values are always strings on the wire.
+type Customer struct {
+	ID           string               `json:"id"`
+	Identifiers  *CustomerIdentifiers `json:"identifiers,omitempty"`
+	Attributes   map[string]string    `json:"attributes"`
+	Unsubscribed bool                 `json:"unsubscribed"`
+	Devices      []CustomerDevice     `json:"devices,omitempty"`
+}
+
+// CustomerAttributesResponse is the decoded shape of GET /v1/customers/{id}/attributes.
+type CustomerAttributesResponse struct {
+	Customer Customer `json:"customer"`
+}
+
+// GetAttributes returns a customer's profile attributes. idType selects
+// which kind of identifier id is; the zero value defaults to IdentifierTypeID.
+// See https://docs.customer.io/api/app/#operation/getPersonAttributes
+func (c *APIClient) GetAttributes(ctx context.Context, id string, idType IdentifierType) (*CustomerAttributesResponse, error) {
+	if id == "" {
+		return nil, ParamError{Param: "id"}
+	}
+	if idType == "" {
+		idType = IdentifierTypeID
+	}
+
+	requestPath := formatPath("/v1/customers/%s/attributes", id) + newQuery().setString("id_type", string(idType)).String()
+
+	var resp CustomerAttributesResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// CustomerActivitiesOptions filters GetCustomerActivities.
+type CustomerActivitiesOptions struct {
+	PaginationOptions
+	IDType IdentifierType
+	Type   string
+	Name   string
+}
+
+// GetCustomerActivities returns activity records (sends, opens, clicks,
+// events, attribute changes, ...) for one customer, most recent first.
+// See https://docs.customer.io/api/app/#operation/getPersonActivities
+func (c *APIClient) GetCustomerActivities(ctx context.Context, customerID string, opts CustomerActivitiesOptions) (*ActivitiesResponse, error) {
+	if customerID == "" {
+		return nil, ParamError{Param: "customerID"}
+	}
+
+	q := opts.PaginationOptions.apply(newQuery()).
+		setString("id_type", string(opts.IDType)).
+		setString("type", opts.Type).
+		setString("name", opts.Name)
+
+	requestPath := formatPath("/v1/customers/%s/activities", customerID) + q.String()
+
+	var resp ActivitiesResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// Message is an entry from GET /v1/customers/{id}/messages — a sent
+// email/push/SMS/etc. and its delivery metadata. Open/click/bounce state is
+// not part of this object; join against GetCustomerActivities (or
+// GetMessage's associations) for delivery lifecycle events.
+type Message struct {
+	ID             string           `json:"id"`
+	DeduplicateID  string           `json:"deduplicate_id,omitempty"`
+	CustomerID     string           `json:"customer_id,omitempty"`
+	CampaignID     int              `json:"campaign_id,omitempty"`
+	ActionID       int              `json:"action_id,omitempty"`
+	Recipient      string           `json:"recipient,omitempty"`
+	Subject        string           `json:"subject,omitempty"`
+	Metrics        map[string]int64 `json:"metrics,omitempty"`
+	Created        int64            `json:"created,omitempty"`
+	FailureMessage string           `json:"failure_message,omitempty"`
+	NewsletterID   *int             `json:"newsletter_id,omitempty"`
+	ContentID      *int             `json:"content_id,omitempty"`
+	BroadcastID    *int             `json:"broadcast_id,omitempty"`
+	Type           string           `json:"type,omitempty"`
+	Forgotten      bool             `json:"forgotten,omitempty"`
+}
+
+// MessagesResponse is the decoded shape of GET /v1/customers/{id}/messages.
+type MessagesResponse struct {
+	Messages []Message `json:"messages"`
+	Next     string    `json:"next,omitempty"`
+}
+
+// CustomerMessagesOptions filters GetCustomerMessages. IDType lets callers
+// look a customer up by email or cio_id directly (id_type=email skips a
+// separate SearchCustomers/GetCustomersByEmail round trip).
+type CustomerMessagesOptions struct {
+	PaginationOptions
+	IDType  IdentifierType
+	StartTS int64
+	EndTS   int64
+}
+
+// GetCustomerMessages returns messages sent to one customer, most recent
+// first. customerID is interpreted according to opts.IDType (default
+// IdentifierTypeID) — pass an email address with IDType: IdentifierTypeEmail
+// to look a customer up by email directly.
+// See https://docs.customer.io/api/app/#operation/getPersonMessages
+func (c *APIClient) GetCustomerMessages(ctx context.Context, customerID string, opts CustomerMessagesOptions) (*MessagesResponse, error) {
+	if customerID == "" {
+		return nil, ParamError{Param: "customerID"}
+	}
+
+	q := opts.PaginationOptions.apply(newQuery()).
+		setString("id_type", string(opts.IDType)).
+		setInt64("start_ts", opts.StartTS).
+		setInt64("end_ts", opts.EndTS)
+
+	requestPath := formatPath("/v1/customers/%s/messages", customerID) + q.String()
+
+	var resp MessagesResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// ObjectIdentifiers identifies an object by the two identifier kinds
+// Customer.io tracks for objects (as opposed to CustomerIdentifiers, which
+// is for customers).
+type ObjectIdentifiers struct {
+	ObjectID    string `json:"object_id,omitempty"`
+	CioObjectID string `json:"cio_object_id,omitempty"`
+}
+
+// CustomerRelationship is a customer's relationship to an object.
+// ObjectTypeID is decoded leniently (json.Number): the schema types it as
+// an integer, but the analogous GetObjectRelationships example shows it as
+// a numeric string.
+type CustomerRelationship struct {
+	ObjectTypeID json.Number       `json:"object_type_id,omitempty"`
+	Identifiers  ObjectIdentifiers `json:"identifiers"`
+	Attributes   map[string]any    `json:"attributes,omitempty"`
+	Timestamps   map[string]int64  `json:"timestamps,omitempty"`
+}
+
+// RelationshipsResponse is the decoded shape of GET /v1/customers/{id}/relationships.
+type RelationshipsResponse struct {
+	Relationships []CustomerRelationship `json:"cio_relationships"`
+	Next          string                 `json:"next,omitempty"`
+}
+
+// GetCustomerRelationships returns the objects a customer is related to.
+// See https://docs.customer.io/api/app/#operation/getPersonRelationships
+func (c *APIClient) GetCustomerRelationships(ctx context.Context, customerID string, opts PaginationOptions) (*RelationshipsResponse, error) {
+	if customerID == "" {
+		return nil, ParamError{Param: "customerID"}
+	}
+
+	requestPath := formatPath("/v1/customers/%s/relationships", customerID) + opts.apply(newQuery()).String()
+
+	var resp RelationshipsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// CustomerSegment is a manual or data-driven segment a customer belongs to.
+type CustomerSegment struct {
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// CustomerSegmentsResponse is the decoded shape of GET /v1/customers/{id}/segments.
+type CustomerSegmentsResponse struct {
+	Segments []CustomerSegment `json:"segments"`
+}
+
+// GetCustomerSegments returns the segments a customer belongs to. idType
+// selects which kind of identifier customerID is; the zero value defaults
+// to IdentifierTypeID. See https://docs.customer.io/api/app/#operation/getPersonSegments
+func (c *APIClient) GetCustomerSegments(ctx context.Context, customerID string, idType IdentifierType) (*CustomerSegmentsResponse, error) {
+	if customerID == "" {
+		return nil, ParamError{Param: "customerID"}
+	}
+	if idType == "" {
+		idType = IdentifierTypeID
+	}
+
+	requestPath := formatPath("/v1/customers/%s/segments", customerID) + newQuery().setString("id_type", string(idType)).String()
+
+	var resp CustomerSegmentsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// SubscriptionTopicPreference is one topic's subscription state for a
+// customer. ID is decoded leniently: the documented schema types it as a
+// string, but example responses show a JSON integer.
+type SubscriptionTopicPreference struct {
+	ID          json.Number `json:"id"`
+	Subscribed  bool        `json:"subscribed"`
+	Name        string      `json:"name,omitempty"`
+	Description string      `json:"description,omitempty"`
+}
+
+// SubscriptionPreferencesHeader is optional branding shown on the hosted
+// subscription preferences page.
+type SubscriptionPreferencesHeader struct {
+	Title    string `json:"title,omitempty"`
+	Subtitle string `json:"subtitle,omitempty"`
+}
+
+// SubscriptionPreferencesCustomer is the customer object returned by
+// GetCustomerSubscriptionPreferences.
+type SubscriptionPreferencesCustomer struct {
+	ID           string                         `json:"id"`
+	Identifiers  *CustomerIdentifiers           `json:"identifiers,omitempty"`
+	Topics       []SubscriptionTopicPreference  `json:"topics,omitempty"`
+	Unsubscribed bool                           `json:"unsubscribed"`
+	Header       *SubscriptionPreferencesHeader `json:"header,omitempty"`
+}
+
+// SubscriptionPreferencesResponse is the decoded shape of
+// GET /v1/customers/{id}/subscription_preferences.
+type SubscriptionPreferencesResponse struct {
+	Customer SubscriptionPreferencesCustomer `json:"customer"`
+}
+
+// CustomerSubscriptionPreferencesOptions configures GetCustomerSubscriptionPreferences.
+type CustomerSubscriptionPreferencesOptions struct {
+	IDType   IdentifierType
+	Language string
+}
+
+// GetCustomerSubscriptionPreferences returns a customer's topic subscription
+// state. See https://docs.customer.io/api/app/#operation/getPersonSubscriptionPreferences
+func (c *APIClient) GetCustomerSubscriptionPreferences(ctx context.Context, customerID string, opts CustomerSubscriptionPreferencesOptions) (*SubscriptionPreferencesResponse, error) {
+	if customerID == "" {
+		return nil, ParamError{Param: "customerID"}
+	}
+
+	q := newQuery().setString("id_type", string(opts.IDType)).setString("language", opts.Language)
+	requestPath := formatPath("/v1/customers/%s/subscription_preferences", customerID) + q.String()
+
+	var resp SubscriptionPreferencesResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// getCustomersAttributesRequest is the POST /v1/customers/attributes body.
+type getCustomersAttributesRequest struct {
+	IDs []string `json:"ids"`
+}
+
+// CustomerAttributesEntry wraps one customer in GetCustomersAttributesResponse.
+type CustomerAttributesEntry struct {
+	Customer Customer `json:"customer"`
+}
+
+// GetCustomersAttributesResponse is the decoded shape of POST /v1/customers/attributes.
+type GetCustomersAttributesResponse struct {
+	Customers []CustomerAttributesEntry `json:"customers"`
+}
+
+// GetCustomersAttributes returns profile attributes for up to 1000
+// customers by id in one call. See https://docs.customer.io/api/app/#operation/getCustomersAttributes
+func (c *APIClient) GetCustomersAttributes(ctx context.Context, ids []string) (*GetCustomersAttributesResponse, error) {
+	if len(ids) == 0 {
+		return nil, ParamError{Param: "ids"}
+	}
+
+	var resp GetCustomersAttributesResponse
+	if err := c.doJSON(ctx, "POST", "/v1/customers/attributes", getCustomersAttributesRequest{IDs: ids}, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// SubscriptionCenterTokenResponse is the decoded shape of
+// GET /v1/subscription_center/{customerId}/token.
+type SubscriptionCenterTokenResponse struct {
+	Token string `json:"token"`
+	URL   string `json:"url,omitempty"`
+}
+
+// GetSubscriptionCenterToken returns a signed token (and hosted URL) a
+// customer can use to manage their own subscription preferences.
+// See https://docs.customer.io/api/app/#operation/getSubscriptionCenterAccessToken
+func (c *APIClient) GetSubscriptionCenterToken(ctx context.Context, customerID string) (*SubscriptionCenterTokenResponse, error) {
+	if customerID == "" {
+		return nil, ParamError{Param: "customerID"}
+	}
+
+	requestPath := formatPath("/v1/subscription_center/%s/token", customerID)
+
+	var resp SubscriptionCenterTokenResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/customers.go
+++ b/customers.go
@@ -134,26 +134,33 @@ func (c *APIClient) GetCustomerActivities(ctx context.Context, customerID string
 	return &resp, nil
 }
 
-// Message is an entry from GET /v1/customers/{id}/messages — a sent
-// email/push/SMS/etc. and its delivery metadata. Open/click/bounce state is
-// not part of this object; join against GetCustomerActivities (or
-// GetMessage's associations) for delivery lifecycle events.
+// Message is a sent email/push/SMS/etc. and its delivery metadata — the
+// shared shape returned by GET /v1/customers/{id}/messages,
+// GET /v1/transactional/{id}/messages, and GET /v1/messages. Open/click/
+// bounce state is not part of this object; join against
+// GetCustomerActivities (or GetMessage's associations) for delivery
+// lifecycle events.
 type Message struct {
-	ID             string           `json:"id"`
-	DeduplicateID  string           `json:"deduplicate_id,omitempty"`
-	CustomerID     string           `json:"customer_id,omitempty"`
-	CampaignID     int              `json:"campaign_id,omitempty"`
-	ActionID       int              `json:"action_id,omitempty"`
-	Recipient      string           `json:"recipient,omitempty"`
-	Subject        string           `json:"subject,omitempty"`
-	Metrics        map[string]int64 `json:"metrics,omitempty"`
-	Created        int64            `json:"created,omitempty"`
-	FailureMessage string           `json:"failure_message,omitempty"`
-	NewsletterID   *int             `json:"newsletter_id,omitempty"`
-	ContentID      *int             `json:"content_id,omitempty"`
-	BroadcastID    *int             `json:"broadcast_id,omitempty"`
-	Type           string           `json:"type,omitempty"`
-	Forgotten      bool             `json:"forgotten,omitempty"`
+	ID                  string               `json:"id"`
+	DeduplicateID       string               `json:"deduplicate_id,omitempty"`
+	CustomerID          string               `json:"customer_id,omitempty"`
+	CustomerIdentifiers *CustomerIdentifiers `json:"customer_identifiers,omitempty"`
+	CampaignID          int                  `json:"campaign_id,omitempty"`
+	ActionID            int                  `json:"action_id,omitempty"`
+	ParentActionID      *int                 `json:"parent_action_id,omitempty"`
+	TriggerEventID      string               `json:"trigger_event_id,omitempty"`
+	Recipient           string               `json:"recipient,omitempty"`
+	Subject             string               `json:"subject,omitempty"`
+	Metrics             map[string]int64     `json:"metrics,omitempty"`
+	Created             int64                `json:"created,omitempty"`
+	FailureMessage      string               `json:"failure_message,omitempty"`
+	NewsletterID        *int                 `json:"newsletter_id,omitempty"`
+	ContentID           *int                 `json:"content_id,omitempty"`
+	BroadcastID         *int                 `json:"broadcast_id,omitempty"`
+	Type                string               `json:"type,omitempty"`
+	Forgotten           bool                 `json:"forgotten,omitempty"`
+	// TrackedResponses' shape isn't documented; kept opaque rather than guessed.
+	TrackedResponses any `json:"tracked_responses,omitempty"`
 }
 
 // MessagesResponse is the decoded shape of GET /v1/customers/{id}/messages.

--- a/customers_test.go
+++ b/customers_test.go
@@ -1,0 +1,286 @@
+package customerio_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/customerio/go-customerio/v3"
+)
+
+func TestSearchCustomers(t *testing.T) {
+	ctx := context.Background()
+
+	resp := map[string]any{
+		"identifiers": []map[string]any{{"id": "1", "email": "a@example.com", "cio_id": "c1"}},
+		"ids":         []string{"1"},
+		"next":        "MDox",
+	}
+	api, rec := apiServer(t, 200, resp)
+
+	filter := customerio.FilterByAttribute("email", customerio.FilterOperatorEq, "a@example.com")
+	got, err := api.SearchCustomers(ctx, filter, customerio.PaginationOptions{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "POST", "/v1/customers?limit=10")
+
+	want := &customerio.SearchCustomersResponse{
+		Identifiers: []customerio.CustomerIdentifiers{{ID: "1", Email: "a@example.com", CioID: "c1"}},
+		IDs:         []string{"1"},
+		Next:        "MDox",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+
+	wantBody := map[string]any{
+		"filter": map[string]any{"attribute": map[string]any{"field": "email", "operator": "eq", "value": "a@example.com"}},
+	}
+	assertJSONEqual(t, rec.body, wantBody)
+}
+
+func TestSearchCustomersComposedFilter(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"identifiers": []any{}, "ids": []any{}})
+
+	filter := customerio.FilterAnd(
+		customerio.FilterBySegment(7),
+		customerio.FilterNot(customerio.FilterByAttribute("plan", customerio.FilterOperatorExists, "")),
+	)
+	if _, err := api.SearchCustomers(context.Background(), filter, customerio.PaginationOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "POST", "/v1/customers")
+
+	wantBody := map[string]any{
+		"filter": map[string]any{
+			"and": []any{
+				map[string]any{"segment": map[string]any{"id": float64(7)}},
+				map[string]any{"not": map[string]any{"attribute": map[string]any{"field": "plan", "operator": "exists"}}},
+			},
+		},
+	}
+	assertJSONEqual(t, rec.body, wantBody)
+}
+
+func TestGetCustomersByEmail(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetCustomersByEmail(context.Background(), ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "email")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"results": []map[string]any{{"id": "1", "email": "a@example.com"}}})
+	got, err := api.GetCustomersByEmail(context.Background(), "a@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/customers?email=a%40example.com")
+	want := &customerio.GetCustomersByEmailResponse{Results: []customerio.CustomerIdentifiers{{ID: "1", Email: "a@example.com"}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestGetAttributes(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetAttributes(context.Background(), "", ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "id")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"customer": map[string]any{
+		"id":           "1",
+		"attributes":   map[string]any{"plan": "gold"},
+		"unsubscribed": false,
+	}})
+	got, err := api.GetAttributes(context.Background(), "1", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/customers/1/attributes?id_type=id")
+	if got.Customer.Attributes["plan"] != "gold" {
+		t.Errorf("unexpected attributes: %#v", got.Customer.Attributes)
+	}
+
+	api2, rec2 := apiServer(t, 200, map[string]any{"customer": map[string]any{"id": "a@example.com"}})
+	if _, err := api2.GetAttributes(context.Background(), "a@example.com", customerio.IdentifierTypeEmail); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec2, "GET", "/v1/customers/a@example.com/attributes?id_type=email")
+}
+
+func TestGetCustomerActivities(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetCustomerActivities(context.Background(), "", customerio.CustomerActivitiesOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "customerID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"activities": []map[string]any{
+		{"id": "act1", "type": "sent_email", "timestamp": 1397566226},
+	}, "next": "abc"})
+	got, err := api.GetCustomerActivities(context.Background(), "1", customerio.CustomerActivitiesOptions{
+		IDType:            customerio.IdentifierTypeID,
+		Type:              "sent_email",
+		PaginationOptions: customerio.PaginationOptions{Limit: 5},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/customers/1/activities?id_type=id&limit=5&type=sent_email")
+	if len(got.Activities) != 1 || got.Activities[0].ID != "act1" || got.Next != "abc" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetCustomerMessages(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetCustomerMessages(context.Background(), "", customerio.CustomerMessagesOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "customerID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"messages": []map[string]any{
+		{"id": "m1", "type": "email", "subject": "hi", "created": 1700000000},
+	}})
+	got, err := api.GetCustomerMessages(context.Background(), "a@example.com", customerio.CustomerMessagesOptions{
+		IDType:  customerio.IdentifierTypeEmail,
+		StartTS: 1690000000,
+		EndTS:   1700000000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/customers/a@example.com/messages?end_ts=1700000000&id_type=email&start_ts=1690000000")
+	if len(got.Messages) != 1 || got.Messages[0].Subject != "hi" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetCustomerRelationships(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetCustomerRelationships(context.Background(), "", customerio.PaginationOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "customerID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"cio_relationships": []map[string]any{
+		{"object_type_id": "1", "identifiers": map[string]any{"object_id": "ae3000"}},
+	}, "next": ""})
+	got, err := api.GetCustomerRelationships(context.Background(), "1", customerio.PaginationOptions{Start: "cursor1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/customers/1/relationships?start=cursor1")
+	if len(got.Relationships) != 1 || got.Relationships[0].Identifiers.ObjectID != "ae3000" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetCustomerSegments(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetCustomerSegments(context.Background(), "", ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "customerID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"segments": []map[string]any{{"id": 3, "name": "VIP"}}})
+	got, err := api.GetCustomerSegments(context.Background(), "1", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/customers/1/segments?id_type=id")
+	if len(got.Segments) != 1 || got.Segments[0].Name != "VIP" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetCustomerSubscriptionPreferences(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetCustomerSubscriptionPreferences(context.Background(), "", customerio.CustomerSubscriptionPreferencesOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "customerID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"customer": map[string]any{
+		"id": "1",
+		"topics": []map[string]any{
+			{"id": 1, "subscribed": true, "name": "Offers"},
+		},
+		"unsubscribed": false,
+	}})
+	got, err := api.GetCustomerSubscriptionPreferences(context.Background(), "1", customerio.CustomerSubscriptionPreferencesOptions{Language: "en"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/customers/1/subscription_preferences?language=en")
+	if len(got.Customer.Topics) != 1 || got.Customer.Topics[0].Name != "Offers" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetCustomersAttributes(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetCustomersAttributes(context.Background(), nil); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "ids")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"customers": []map[string]any{
+		{"customer": map[string]any{"id": "1", "attributes": map[string]any{"plan": "gold"}}},
+	}})
+	got, err := api.GetCustomersAttributes(context.Background(), []string{"1", "2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "POST", "/v1/customers/attributes")
+	wantBody := map[string]any{"ids": []any{"1", "2"}}
+	assertJSONEqual(t, rec.body, wantBody)
+	if len(got.Customers) != 1 || got.Customers[0].Customer.ID != "1" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetSubscriptionCenterToken(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetSubscriptionCenterToken(context.Background(), ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "customerID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"token": "tok123", "url": "https://track.customer.io/u/i/tok123/"})
+	got, err := api.GetSubscriptionCenterToken(context.Background(), "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/subscription_center/1/token")
+	if got.Token != "tok123" {
+		t.Errorf("unexpected token: %#v", got)
+	}
+}
+
+func TestCustomersEndpointsError(t *testing.T) {
+	api, _ := apiServer(t, 404, map[string]any{"errors": []map[string]any{{"detail": "not found"}}})
+
+	_, err := api.GetAttributes(context.Background(), "missing", "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	cioErr, ok := err.(*customerio.CustomerIOError)
+	if !ok {
+		t.Fatalf("expected *CustomerIOError, got %T", err)
+	}
+	if cioErr.StatusCode() != 404 {
+		t.Errorf("expected status 404, got %d", cioErr.StatusCode())
+	}
+}

--- a/filter.go
+++ b/filter.go
@@ -1,0 +1,103 @@
+package customerio
+
+// FilterOperator is a comparison operator supported in attribute and object
+// attribute conditions.
+type FilterOperator string
+
+const (
+	FilterOperatorEq     FilterOperator = "eq"
+	FilterOperatorExists FilterOperator = "exists"
+)
+
+// AudienceFilter composes a boolean filter over customers, used by
+// SearchCustomers and CreateCustomersExport. Build a leaf with
+// FilterBySegment or FilterByAttribute; compose leaves with FilterAnd,
+// FilterOr, or FilterNot. Exactly one of the fields is set on any given
+// node — this mirrors the AudienceFilter union type in customerio-node's
+// lib/types.ts, flattened to a single struct since Go has no union types.
+type AudienceFilter struct {
+	Segment   *SegmentCondition   `json:"segment,omitempty"`
+	Attribute *AttributeCondition `json:"attribute,omitempty"`
+	And       []AudienceFilter    `json:"and,omitempty"`
+	Or        []AudienceFilter    `json:"or,omitempty"`
+	Not       *AudienceFilter     `json:"not,omitempty"`
+}
+
+// SegmentCondition matches everyone in a given segment.
+type SegmentCondition struct {
+	ID int `json:"id"`
+}
+
+// AttributeCondition matches people whose attribute satisfies an operator
+// against a value. Value is only meaningful for FilterOperatorEq; omit it
+// for FilterOperatorExists.
+type AttributeCondition struct {
+	Field    string         `json:"field"`
+	Operator FilterOperator `json:"operator"`
+	Value    string         `json:"value,omitempty"`
+}
+
+// FilterBySegment builds a leaf AudienceFilter matching everyone in segment id.
+func FilterBySegment(id int) AudienceFilter {
+	return AudienceFilter{Segment: &SegmentCondition{ID: id}}
+}
+
+// FilterByAttribute builds a leaf AudienceFilter matching people whose
+// attribute field satisfies operator (and value, for FilterOperatorEq).
+func FilterByAttribute(field string, operator FilterOperator, value string) AudienceFilter {
+	return AudienceFilter{Attribute: &AttributeCondition{Field: field, Operator: operator, Value: value}}
+}
+
+// FilterAnd composes filters that must all match.
+func FilterAnd(filters ...AudienceFilter) AudienceFilter {
+	return AudienceFilter{And: filters}
+}
+
+// FilterOr composes filters where at least one must match.
+func FilterOr(filters ...AudienceFilter) AudienceFilter {
+	return AudienceFilter{Or: filters}
+}
+
+// FilterNot negates a filter.
+func FilterNot(filter AudienceFilter) AudienceFilter {
+	return AudienceFilter{Not: &filter}
+}
+
+// ObjectFilter composes a boolean filter over objects, used by FindObjects.
+// Build a leaf with ObjectFilterByAttribute; compose leaves with
+// ObjectFilterAnd, ObjectFilterOr, or ObjectFilterNot.
+type ObjectFilter struct {
+	ObjectAttribute *ObjectAttributeCondition `json:"object_attribute,omitempty"`
+	And             []ObjectFilter            `json:"and,omitempty"`
+	Or              []ObjectFilter            `json:"or,omitempty"`
+	Not             *ObjectFilter             `json:"not,omitempty"`
+}
+
+// ObjectAttributeCondition matches objects of type TypeID whose attribute
+// field satisfies operator (and value, for FilterOperatorEq).
+type ObjectAttributeCondition struct {
+	Field    string         `json:"field"`
+	Operator FilterOperator `json:"operator"`
+	Value    string         `json:"value,omitempty"`
+	TypeID   int            `json:"type_id"`
+}
+
+// ObjectFilterByAttribute builds a leaf ObjectFilter.
+func ObjectFilterByAttribute(field string, operator FilterOperator, value string, typeID int) ObjectFilter {
+	return ObjectFilter{ObjectAttribute: &ObjectAttributeCondition{Field: field, Operator: operator, Value: value, TypeID: typeID}}
+}
+
+// ObjectFilterAnd composes filters that must all match.
+func ObjectFilterAnd(filters ...ObjectFilter) ObjectFilter {
+	return ObjectFilter{And: filters}
+}
+
+// ObjectFilterOr composes filters where at least one must match.
+func ObjectFilterOr(filters ...ObjectFilter) ObjectFilter {
+	return ObjectFilter{Or: filters}
+}
+
+// ObjectFilterNot negates a filter.
+func ObjectFilterNot(filter ObjectFilter) ObjectFilter {
+	return ObjectFilter{Not: &filter}
+}

--- a/messages.go
+++ b/messages.go
@@ -1,0 +1,127 @@
+package customerio
+
+import "context"
+
+// MessagesOptions filters GetMessages, the cross-resource message list —
+// unlike GetCustomerMessages/GetTransactionalMessageDeliveries, it isn't
+// scoped to a single customer or transactional template; the *_id filters
+// narrow it to a specific campaign/action/newsletter/transactional/etc.
+type MessagesOptions struct {
+	PaginationOptions
+	Drafts              *bool
+	Metric              string
+	Type                string
+	CampaignID          string
+	ActionID            string
+	NewsletterID        string
+	TransactionalID     string
+	TriggerID           string
+	TemplateID          string
+	ContentID           string
+	StartTS             int64
+	EndTS               int64
+	Associations        *bool
+	GetTrackedResponses *bool
+}
+
+// GetMessages returns messages across the whole workspace, most recent
+// first, optionally filtered to one campaign/action/newsletter/
+// transactional template/trigger/template/content id.
+// See https://docs.customer.io/api/app/#operation/getMessages
+func (c *APIClient) GetMessages(ctx context.Context, opts MessagesOptions) (*MessagesResponse, error) {
+	q := opts.PaginationOptions.apply(newQuery()).
+		setBool("drafts", opts.Drafts).
+		setString("metric", opts.Metric).
+		setString("type", opts.Type).
+		setString("campaign_id", opts.CampaignID).
+		setString("action_id", opts.ActionID).
+		setString("newsletter_id", opts.NewsletterID).
+		setString("transactional_id", opts.TransactionalID).
+		setString("trigger_id", opts.TriggerID).
+		setString("template_id", opts.TemplateID).
+		setString("content_id", opts.ContentID).
+		setInt64("start_ts", opts.StartTS).
+		setInt64("end_ts", opts.EndTS).
+		setBool("associations", opts.Associations).
+		setBool("get_tracked_responses", opts.GetTrackedResponses)
+
+	requestPath := "/v1/messages" + q.String()
+
+	var resp MessagesResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// MessageOptions controls GetMessage's response detail.
+type MessageOptions struct {
+	ArchivedMessage     *bool
+	Associations        *bool
+	GetTrackedResponses *bool
+}
+
+// MessageResponse wraps a single Message.
+type MessageResponse struct {
+	Message Message `json:"message"`
+}
+
+// GetMessage returns one message by id.
+// See https://docs.customer.io/api/app/#operation/getMessage
+func (c *APIClient) GetMessage(ctx context.Context, messageID string, opts MessageOptions) (*MessageResponse, error) {
+	if messageID == "" {
+		return nil, ParamError{Param: "messageID"}
+	}
+
+	q := newQuery().
+		setBool("archived_message", opts.ArchivedMessage).
+		setBool("associations", opts.Associations).
+		setBool("get_tracked_responses", opts.GetTrackedResponses)
+	requestPath := formatPath("/v1/messages/%s", messageID) + q.String()
+
+	var resp MessageResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// ArchivedMessage is a message's full rendered content, as delivered.
+type ArchivedMessage struct {
+	ID            string            `json:"id,omitempty"`
+	Body          string            `json:"body,omitempty"`
+	From          string            `json:"from,omitempty"`
+	ReplyTo       string            `json:"reply_to,omitempty"`
+	Recipient     string            `json:"recipient,omitempty"`
+	Subject       string            `json:"subject,omitempty"`
+	CC            string            `json:"cc,omitempty"`
+	BCC           string            `json:"bcc,omitempty"`
+	FakeBCC       *bool             `json:"fake_bcc,omitempty"`
+	PreheaderText string            `json:"preheader_text,omitempty"`
+	URL           string            `json:"url,omitempty"`
+	RequestMethod string            `json:"request_method,omitempty"`
+	Headers       map[string]string `json:"headers,omitempty"`
+	Forgotten     bool              `json:"forgotten,omitempty"`
+}
+
+// ArchivedMessageResponse is the decoded shape of
+// GET /v1/messages/{id}/archived_message.
+type ArchivedMessageResponse struct {
+	ArchivedMessage ArchivedMessage `json:"archived_message"`
+}
+
+// GetArchivedMessage returns a message's full rendered content. This
+// endpoint is rate-limited by the API (10 requests/second) — the returned
+// error's status will be 429 if that limit is exceeded.
+// See https://docs.customer.io/api/app/#operation/getArchivedMessage
+func (c *APIClient) GetArchivedMessage(ctx context.Context, messageID string) (*ArchivedMessageResponse, error) {
+	if messageID == "" {
+		return nil, ParamError{Param: "messageID"}
+	}
+
+	var resp ArchivedMessageResponse
+	if err := c.doJSON(ctx, "GET", formatPath("/v1/messages/%s/archived_message", messageID), nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/messages_test.go
+++ b/messages_test.go
@@ -1,0 +1,87 @@
+package customerio_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/customerio/go-customerio/v3"
+)
+
+func TestGetMessages(t *testing.T) {
+	drafts := false
+	api, rec := apiServer(t, 200, map[string]any{"messages": []map[string]any{
+		{"id": "m1", "type": "email", "campaign_id": 4},
+	}})
+	got, err := api.GetMessages(context.Background(), customerio.MessagesOptions{
+		Drafts:            &drafts,
+		Type:              "email",
+		CampaignID:        "4",
+		PaginationOptions: customerio.PaginationOptions{Limit: 50},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/messages?campaign_id=4&drafts=false&limit=50&type=email")
+	if len(got.Messages) != 1 || got.Messages[0].CampaignID != 4 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetMessagesNoOptions(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"messages": []any{}})
+	if _, err := api.GetMessages(context.Background(), customerio.MessagesOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/messages")
+}
+
+func TestGetMessage(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetMessage(context.Background(), "", customerio.MessageOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "messageID")
+	}
+
+	associations := true
+	api, rec := apiServer(t, 200, map[string]any{"message": map[string]any{"id": "m1", "subject": "hi"}})
+	got, err := api.GetMessage(context.Background(), "m1", customerio.MessageOptions{Associations: &associations})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/messages/m1?associations=true")
+	if got.Message.Subject != "hi" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetArchivedMessage(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetArchivedMessage(context.Background(), ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "messageID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"archived_message": map[string]any{"id": "m1", "body": "<html></html>"}})
+	got, err := api.GetArchivedMessage(context.Background(), "m1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/messages/m1/archived_message")
+	if got.ArchivedMessage.Body != "<html></html>" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetArchivedMessageRateLimited(t *testing.T) {
+	api, _ := apiServer(t, 429, map[string]any{"errors": []map[string]any{{"detail": "rate limited"}}})
+	_, err := api.GetArchivedMessage(context.Background(), "m1")
+	cioErr, ok := err.(*customerio.CustomerIOError)
+	if !ok {
+		t.Fatalf("expected *CustomerIOError, got %T", err)
+	}
+	if cioErr.StatusCode() != 429 {
+		t.Errorf("expected status 429, got %d", cioErr.StatusCode())
+	}
+}

--- a/newsletters.go
+++ b/newsletters.go
@@ -1,0 +1,521 @@
+package customerio
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// Newsletter is a one-off or recurring bulk send to a segment. Unlike
+// Campaign/Broadcast, newsletters have no documented State field.
+type Newsletter struct {
+	ID                  int      `json:"id"`
+	DeduplicateID       string   `json:"deduplicate_id,omitempty"`
+	ContentIDs          []int    `json:"content_ids,omitempty"`
+	Name                string   `json:"name,omitempty"`
+	SentAt              int64    `json:"sent_at,omitempty"`
+	Created             int64    `json:"created,omitempty"`
+	Updated             int64    `json:"updated,omitempty"`
+	Type                string   `json:"type,omitempty"`
+	Tags                []string `json:"tags,omitempty"`
+	RecipientSegmentIDs []int    `json:"recipient_segment_ids,omitempty"`
+	SubscriptionTopicID *int     `json:"subscription_topic_id,omitempty"`
+}
+
+// NewsletterResponse wraps a single Newsletter.
+type NewsletterResponse struct {
+	Newsletter Newsletter `json:"newsletter"`
+}
+
+// ListNewslettersOptions filters ListNewsletters.
+type ListNewslettersOptions struct {
+	PaginationOptions
+	Sort SortDirection
+}
+
+// ListNewslettersResponse is the decoded shape of GET /v1/newsletters.
+type ListNewslettersResponse struct {
+	Newsletters []Newsletter `json:"newsletters"`
+}
+
+// ListNewsletters returns every newsletter defined in the workspace.
+// See https://docs.customer.io/api/app/#operation/listNewsletters
+func (c *APIClient) ListNewsletters(ctx context.Context, opts ListNewslettersOptions) (*ListNewslettersResponse, error) {
+	q := opts.PaginationOptions.apply(newQuery()).setString("sort", string(opts.Sort))
+	requestPath := "/v1/newsletters" + q.String()
+
+	var resp ListNewslettersResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// CreateNewsletter creates a newsletter. data is free-form, matching the
+// App API's own untyped request body for this endpoint.
+// See https://docs.customer.io/api/app/#operation/createNewsletter
+func (c *APIClient) CreateNewsletter(ctx context.Context, data map[string]any) (*NewsletterResponse, error) {
+	var resp NewsletterResponse
+	if err := c.doJSON(ctx, "POST", "/v1/newsletters", data, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetNewsletter returns one newsletter by id.
+// See https://docs.customer.io/api/app/#operation/getNewsletter
+func (c *APIClient) GetNewsletter(ctx context.Context, newsletterID string) (*NewsletterResponse, error) {
+	if newsletterID == "" {
+		return nil, ParamError{Param: "newsletterID"}
+	}
+
+	var resp NewsletterResponse
+	if err := c.doJSON(ctx, "GET", formatPath("/v1/newsletters/%s", newsletterID), nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// DeleteNewsletter deletes a newsletter by id.
+// See https://docs.customer.io/api/app/#operation/deleteNewsletter
+func (c *APIClient) DeleteNewsletter(ctx context.Context, newsletterID string) error {
+	if newsletterID == "" {
+		return ParamError{Param: "newsletterID"}
+	}
+
+	return c.doJSON(ctx, "DELETE", formatPath("/v1/newsletters/%s", newsletterID), nil, nil, 200, 204)
+}
+
+// NewsletterContent is one language/variant's rendered content for a newsletter.
+type NewsletterContent struct {
+	ID            int               `json:"id,omitempty"`
+	NewsletterID  json.Number       `json:"newsletter_id,omitempty"`
+	DeduplicateID string            `json:"deduplicate_id,omitempty"`
+	Name          string            `json:"name,omitempty"`
+	Layout        string            `json:"layout,omitempty"`
+	Body          string            `json:"body,omitempty"`
+	BodyAMP       string            `json:"body_amp,omitempty"`
+	Language      string            `json:"language,omitempty"`
+	Type          string            `json:"type,omitempty"`
+	From          string            `json:"from,omitempty"`
+	FromID        *int              `json:"from_id,omitempty"`
+	ReplyTo       string            `json:"reply_to,omitempty"`
+	ReplyToID     *int              `json:"reply_to_id,omitempty"`
+	Preprocessor  string            `json:"preprocessor,omitempty"`
+	Recipient     string            `json:"recipient,omitempty"`
+	Subject       string            `json:"subject,omitempty"`
+	CC            string            `json:"cc,omitempty"`
+	BCC           string            `json:"bcc,omitempty"`
+	FakeBCC       *bool             `json:"fake_bcc,omitempty"`
+	Headers       map[string]string `json:"headers,omitempty"`
+}
+
+// NewsletterContentsResponse is the decoded shape of GET /v1/newsletters/{id}/contents.
+type NewsletterContentsResponse struct {
+	Contents []NewsletterContent `json:"contents"`
+}
+
+// GetNewsletterContents returns every content variant for a newsletter.
+// See https://docs.customer.io/api/app/#operation/getNewsletterContents
+func (c *APIClient) GetNewsletterContents(ctx context.Context, newsletterID string) (*NewsletterContentsResponse, error) {
+	if newsletterID == "" {
+		return nil, ParamError{Param: "newsletterID"}
+	}
+
+	var resp NewsletterContentsResponse
+	if err := c.doJSON(ctx, "GET", formatPath("/v1/newsletters/%s/contents", newsletterID), nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// NewsletterContentResponse wraps a single NewsletterContent — shared by
+// the content, language, and test-group-language endpoints below, which
+// all return the same object shape.
+type NewsletterContentResponse struct {
+	Content NewsletterContent `json:"content"`
+}
+
+// GetNewsletterContent returns one content variant by id.
+// See https://docs.customer.io/api/app/#operation/getNewsletterContent
+func (c *APIClient) GetNewsletterContent(ctx context.Context, newsletterID, contentID string) (*NewsletterContentResponse, error) {
+	if newsletterID == "" {
+		return nil, ParamError{Param: "newsletterID"}
+	}
+	if contentID == "" {
+		return nil, ParamError{Param: "contentID"}
+	}
+
+	requestPath := formatPath("/v1/newsletters/%s/contents/%s", newsletterID, contentID)
+
+	var resp NewsletterContentResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// UpdateNewsletterContent updates a content variant. data is free-form.
+// See https://docs.customer.io/api/app/#operation/updateNewsletterContent
+func (c *APIClient) UpdateNewsletterContent(ctx context.Context, newsletterID, contentID string, data map[string]any) (*NewsletterContentResponse, error) {
+	if newsletterID == "" {
+		return nil, ParamError{Param: "newsletterID"}
+	}
+	if contentID == "" {
+		return nil, ParamError{Param: "contentID"}
+	}
+
+	requestPath := formatPath("/v1/newsletters/%s/contents/%s", newsletterID, contentID)
+
+	var resp NewsletterContentResponse
+	if err := c.doJSON(ctx, "PUT", requestPath, data, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetNewsletterContentMetrics returns send/delivery/engagement counts over
+// time for one newsletter content variant.
+// See https://docs.customer.io/api/app/#operation/getNewsletterContentMetrics
+func (c *APIClient) GetNewsletterContentMetrics(ctx context.Context, newsletterID, contentID string, opts TransactionalMetricsOptions) (*TransactionalMetricsResponse, error) {
+	if newsletterID == "" {
+		return nil, ParamError{Param: "newsletterID"}
+	}
+	if contentID == "" {
+		return nil, ParamError{Param: "contentID"}
+	}
+
+	q := newQuery().setString("period", string(opts.Period)).setInt("steps", opts.Steps)
+	requestPath := formatPath("/v1/newsletters/%s/contents/%s/metrics", newsletterID, contentID) + q.String()
+
+	var resp TransactionalMetricsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetNewsletterContentMetricsLinks returns per-link click metrics for one
+// newsletter content variant.
+// See https://docs.customer.io/api/app/#operation/getNewsletterContentMetricsLinks
+func (c *APIClient) GetNewsletterContentMetricsLinks(ctx context.Context, newsletterID, contentID string, opts TransactionalLinkMetricsOptions) (*TransactionalLinkMetricsResponse, error) {
+	if newsletterID == "" {
+		return nil, ParamError{Param: "newsletterID"}
+	}
+	if contentID == "" {
+		return nil, ParamError{Param: "contentID"}
+	}
+
+	q := newQuery().
+		setString("period", string(opts.Period)).
+		setInt("steps", opts.Steps).
+		setBool("unique", opts.Unique)
+	requestPath := formatPath("/v1/newsletters/%s/contents/%s/metrics/links", newsletterID, contentID) + q.String()
+
+	var resp TransactionalLinkMetricsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetNewsletterMetrics returns send/delivery/engagement counts over time
+// for a whole newsletter.
+// See https://docs.customer.io/api/app/#operation/getNewsletterMetrics
+func (c *APIClient) GetNewsletterMetrics(ctx context.Context, newsletterID string, opts TransactionalMetricsOptions) (*TransactionalMetricsResponse, error) {
+	if newsletterID == "" {
+		return nil, ParamError{Param: "newsletterID"}
+	}
+
+	q := newQuery().setString("period", string(opts.Period)).setInt("steps", opts.Steps)
+	requestPath := formatPath("/v1/newsletters/%s/metrics", newsletterID) + q.String()
+
+	var resp TransactionalMetricsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetNewsletterMetricsLinks returns per-link click metrics for a whole newsletter.
+// See https://docs.customer.io/api/app/#operation/getNewsletterMetricsLinks
+func (c *APIClient) GetNewsletterMetricsLinks(ctx context.Context, newsletterID string, opts TransactionalLinkMetricsOptions) (*TransactionalLinkMetricsResponse, error) {
+	if newsletterID == "" {
+		return nil, ParamError{Param: "newsletterID"}
+	}
+
+	q := newQuery().
+		setString("period", string(opts.Period)).
+		setInt("steps", opts.Steps).
+		setBool("unique", opts.Unique)
+	requestPath := formatPath("/v1/newsletters/%s/metrics/links", newsletterID) + q.String()
+
+	var resp TransactionalLinkMetricsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// NewsletterMessagesOptions filters GetNewsletterMessages.
+type NewsletterMessagesOptions struct {
+	PaginationOptions
+	Metric              string
+	Type                NewsletterChannelType
+	StartTS             int64
+	EndTS               int64
+	GetTrackedResponses *bool
+}
+
+// GetNewsletterMessages returns messages sent from a newsletter.
+// See https://docs.customer.io/api/app/#operation/getNewsletterMessages
+func (c *APIClient) GetNewsletterMessages(ctx context.Context, newsletterID string, opts NewsletterMessagesOptions) (*MessagesResponse, error) {
+	if newsletterID == "" {
+		return nil, ParamError{Param: "newsletterID"}
+	}
+
+	q := opts.PaginationOptions.apply(newQuery()).
+		setString("metric", opts.Metric).
+		setString("type", string(opts.Type)).
+		setInt64("start_ts", opts.StartTS).
+		setInt64("end_ts", opts.EndTS).
+		setBool("get_tracked_responses", opts.GetTrackedResponses)
+	requestPath := formatPath("/v1/newsletters/%s/messages", newsletterID) + q.String()
+
+	var resp MessagesResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// SendNewsletter sends a newsletter immediately. data is free-form.
+// See https://docs.customer.io/api/app/#operation/sendNewsletter
+func (c *APIClient) SendNewsletter(ctx context.Context, newsletterID string, data map[string]any) (*NewsletterResponse, error) {
+	if newsletterID == "" {
+		return nil, ParamError{Param: "newsletterID"}
+	}
+
+	var resp NewsletterResponse
+	if err := c.doJSON(ctx, "POST", formatPath("/v1/newsletters/%s/send", newsletterID), data, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// ScheduleNewsletter schedules a newsletter to send later. data is free-form.
+// See https://docs.customer.io/api/app/#operation/scheduleNewsletter
+func (c *APIClient) ScheduleNewsletter(ctx context.Context, newsletterID string, data map[string]any) (*NewsletterResponse, error) {
+	if newsletterID == "" {
+		return nil, ParamError{Param: "newsletterID"}
+	}
+
+	var resp NewsletterResponse
+	if err := c.doJSON(ctx, "POST", formatPath("/v1/newsletters/%s/schedule", newsletterID), data, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// CreateNewsletterLanguage adds a language variant to a newsletter. data is
+// free-form (must include the language tag — see the App API docs for the
+// expected field name).
+// See https://docs.customer.io/api/app/#operation/createNewsletterLanguage
+func (c *APIClient) CreateNewsletterLanguage(ctx context.Context, newsletterID string, data map[string]any) (*NewsletterContentResponse, error) {
+	if newsletterID == "" {
+		return nil, ParamError{Param: "newsletterID"}
+	}
+
+	var resp NewsletterContentResponse
+	if err := c.doJSON(ctx, "POST", formatPath("/v1/newsletters/%s/language", newsletterID), data, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetNewsletterLanguage returns one language variant of a newsletter.
+// See https://docs.customer.io/api/app/#operation/getNewsletterLanguage
+func (c *APIClient) GetNewsletterLanguage(ctx context.Context, newsletterID, language string) (*NewsletterContentResponse, error) {
+	if newsletterID == "" {
+		return nil, ParamError{Param: "newsletterID"}
+	}
+	if language == "" {
+		return nil, ParamError{Param: "language"}
+	}
+
+	requestPath := formatPath("/v1/newsletters/%s/language/%s", newsletterID, language)
+
+	var resp NewsletterContentResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// UpdateNewsletterLanguage updates a language variant of a newsletter. data
+// is free-form.
+// See https://docs.customer.io/api/app/#operation/updateNewsletterLanguage
+func (c *APIClient) UpdateNewsletterLanguage(ctx context.Context, newsletterID, language string, data map[string]any) (*NewsletterContentResponse, error) {
+	if newsletterID == "" {
+		return nil, ParamError{Param: "newsletterID"}
+	}
+	if language == "" {
+		return nil, ParamError{Param: "language"}
+	}
+
+	requestPath := formatPath("/v1/newsletters/%s/language/%s", newsletterID, language)
+
+	var resp NewsletterContentResponse
+	if err := c.doJSON(ctx, "PUT", requestPath, data, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// DeleteNewsletterLanguage removes a language variant from a newsletter.
+// See https://docs.customer.io/api/app/#operation/deleteNewsletterLanguage
+func (c *APIClient) DeleteNewsletterLanguage(ctx context.Context, newsletterID, language string) error {
+	if newsletterID == "" {
+		return ParamError{Param: "newsletterID"}
+	}
+	if language == "" {
+		return ParamError{Param: "language"}
+	}
+
+	requestPath := formatPath("/v1/newsletters/%s/language/%s", newsletterID, language)
+	return c.doJSON(ctx, "DELETE", requestPath, nil, nil, 200, 204)
+}
+
+// NewsletterTestGroup is one A/B test variant of a newsletter. ContentIDs
+// is decoded leniently (json.Number elements): the schema declares it as
+// string[], but example responses show integers.
+type NewsletterTestGroup struct {
+	ID         int           `json:"id"`
+	Name       string        `json:"name,omitempty"`
+	Label      string        `json:"label,omitempty"`
+	Winner     bool          `json:"winner,omitempty"`
+	ContentIDs []json.Number `json:"content_ids,omitempty"`
+}
+
+// NewsletterTestGroupsResponse is the decoded shape of GET /v1/newsletters/{id}/test_groups.
+type NewsletterTestGroupsResponse struct {
+	TestGroups []NewsletterTestGroup `json:"test_groups"`
+}
+
+// GetNewsletterTestGroups returns every A/B test group defined for a newsletter.
+// See https://docs.customer.io/api/app/#operation/getNewsletterTestGroups
+func (c *APIClient) GetNewsletterTestGroups(ctx context.Context, newsletterID string) (*NewsletterTestGroupsResponse, error) {
+	if newsletterID == "" {
+		return nil, ParamError{Param: "newsletterID"}
+	}
+
+	var resp NewsletterTestGroupsResponse
+	if err := c.doJSON(ctx, "GET", formatPath("/v1/newsletters/%s/test_groups", newsletterID), nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// NewsletterTestGroupResponse wraps a single NewsletterTestGroup.
+type NewsletterTestGroupResponse struct {
+	TestGroup NewsletterTestGroup `json:"test_group"`
+}
+
+// CreateNewsletterTestGroup adds a new (empty) A/B test group to a
+// newsletter — this endpoint takes no request body.
+// See https://docs.customer.io/api/app/#operation/createNewsletterTestGroup
+func (c *APIClient) CreateNewsletterTestGroup(ctx context.Context, newsletterID string) (*NewsletterTestGroupResponse, error) {
+	if newsletterID == "" {
+		return nil, ParamError{Param: "newsletterID"}
+	}
+
+	var resp NewsletterTestGroupResponse
+	if err := c.doJSON(ctx, "POST", formatPath("/v1/newsletters/%s/test_groups", newsletterID), nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// CreateNewsletterTestGroupLanguage adds a language variant to a test
+// group's content. data is free-form. Note the wire path uses singular
+// "test_group" here (and in the three methods below), while
+// GetNewsletterTestGroups/CreateNewsletterTestGroup use plural
+// "test_groups" — a real App API path inconsistency, not a typo.
+// See https://docs.customer.io/api/app/#operation/createNewsletterTestGroupLanguage
+func (c *APIClient) CreateNewsletterTestGroupLanguage(ctx context.Context, newsletterID, testGroupID string, data map[string]any) (*NewsletterContentResponse, error) {
+	if newsletterID == "" {
+		return nil, ParamError{Param: "newsletterID"}
+	}
+	if testGroupID == "" {
+		return nil, ParamError{Param: "testGroupID"}
+	}
+
+	requestPath := formatPath("/v1/newsletters/%s/test_group/%s/language", newsletterID, testGroupID)
+
+	var resp NewsletterContentResponse
+	if err := c.doJSON(ctx, "POST", requestPath, data, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetNewsletterTestGroupLanguage returns one language variant of a test group.
+// See https://docs.customer.io/api/app/#operation/getNewsletterTestGroupLanguage
+func (c *APIClient) GetNewsletterTestGroupLanguage(ctx context.Context, newsletterID, testGroupID, language string) (*NewsletterContentResponse, error) {
+	if newsletterID == "" {
+		return nil, ParamError{Param: "newsletterID"}
+	}
+	if testGroupID == "" {
+		return nil, ParamError{Param: "testGroupID"}
+	}
+	if language == "" {
+		return nil, ParamError{Param: "language"}
+	}
+
+	requestPath := formatPath("/v1/newsletters/%s/test_group/%s/language/%s", newsletterID, testGroupID, language)
+
+	var resp NewsletterContentResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// UpdateNewsletterTestGroupLanguage updates a language variant of a test
+// group. data is free-form.
+// See https://docs.customer.io/api/app/#operation/updateNewsletterTestGroupLanguage
+func (c *APIClient) UpdateNewsletterTestGroupLanguage(ctx context.Context, newsletterID, testGroupID, language string, data map[string]any) (*NewsletterContentResponse, error) {
+	if newsletterID == "" {
+		return nil, ParamError{Param: "newsletterID"}
+	}
+	if testGroupID == "" {
+		return nil, ParamError{Param: "testGroupID"}
+	}
+	if language == "" {
+		return nil, ParamError{Param: "language"}
+	}
+
+	requestPath := formatPath("/v1/newsletters/%s/test_group/%s/language/%s", newsletterID, testGroupID, language)
+
+	var resp NewsletterContentResponse
+	if err := c.doJSON(ctx, "PUT", requestPath, data, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// DeleteNewsletterTestGroupLanguage removes a language variant from a test group.
+// See https://docs.customer.io/api/app/#operation/deleteNewsletterTestGroupLanguage
+func (c *APIClient) DeleteNewsletterTestGroupLanguage(ctx context.Context, newsletterID, testGroupID, language string) error {
+	if newsletterID == "" {
+		return ParamError{Param: "newsletterID"}
+	}
+	if testGroupID == "" {
+		return ParamError{Param: "testGroupID"}
+	}
+	if language == "" {
+		return ParamError{Param: "language"}
+	}
+
+	requestPath := formatPath("/v1/newsletters/%s/test_group/%s/language/%s", newsletterID, testGroupID, language)
+	return c.doJSON(ctx, "DELETE", requestPath, nil, nil, 200, 204)
+}

--- a/newsletters.go
+++ b/newsletters.go
@@ -35,6 +35,7 @@ type ListNewslettersOptions struct {
 // ListNewslettersResponse is the decoded shape of GET /v1/newsletters.
 type ListNewslettersResponse struct {
 	Newsletters []Newsletter `json:"newsletters"`
+	Next        string       `json:"next,omitempty"`
 }
 
 // ListNewsletters returns every newsletter defined in the workspace.

--- a/newsletters_test.go
+++ b/newsletters_test.go
@@ -1,0 +1,334 @@
+package customerio_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/customerio/go-customerio/v3"
+)
+
+func TestListNewsletters(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"newsletters": []map[string]any{{"id": 1, "name": "Weekly"}}})
+	got, err := api.ListNewsletters(context.Background(), customerio.ListNewslettersOptions{Sort: customerio.SortDescending})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/newsletters?sort=desc")
+	if len(got.Newsletters) != 1 || got.Newsletters[0].Name != "Weekly" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestCreateNewsletter(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"newsletter": map[string]any{"id": 1}})
+	data := map[string]any{"name": "Weekly"}
+	got, err := api.CreateNewsletter(context.Background(), data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "POST", "/v1/newsletters")
+	assertJSONEqual(t, rec.body, data)
+	if got.Newsletter.ID != 1 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetNewsletter(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetNewsletter(context.Background(), ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "newsletterID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"newsletter": map[string]any{"id": 1}})
+	if _, err := api.GetNewsletter(context.Background(), "1"); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/newsletters/1")
+}
+
+func TestDeleteNewsletter(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if err := api.DeleteNewsletter(context.Background(), ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "newsletterID")
+	}
+
+	api, rec := apiServer(t, 204, nil)
+	if err := api.DeleteNewsletter(context.Background(), "1"); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "DELETE", "/v1/newsletters/1")
+}
+
+func TestNewsletterContents(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetNewsletterContents(context.Background(), ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "newsletterID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"contents": []map[string]any{{"id": 5, "language": "en"}}})
+	got, err := api.GetNewsletterContents(context.Background(), "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/newsletters/1/contents")
+	if len(got.Contents) != 1 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestNewsletterContent(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetNewsletterContent(context.Background(), "", "5"); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "newsletterID")
+	}
+	if _, err := api.GetNewsletterContent(context.Background(), "1", ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "contentID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"content": map[string]any{"id": 5}})
+	if _, err := api.GetNewsletterContent(context.Background(), "1", "5"); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/newsletters/1/contents/5")
+
+	data := map[string]any{"subject": "hi"}
+	if _, err := api.UpdateNewsletterContent(context.Background(), "1", "5", data); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "PUT", "/v1/newsletters/1/contents/5")
+	assertJSONEqual(t, rec.body, data)
+}
+
+func TestNewsletterContentMetrics(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"metric": map[string]any{"series": map[string]any{}}})
+	if _, err := api.GetNewsletterContentMetrics(context.Background(), "1", "5", customerio.TransactionalMetricsOptions{Period: customerio.MetricsPeriodMonths, Steps: 1}); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/newsletters/1/contents/5/metrics?period=months&steps=1")
+
+	if _, err := api.GetNewsletterContentMetrics(context.Background(), "", "5", customerio.TransactionalMetricsOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "newsletterID")
+	}
+	if _, err := api.GetNewsletterContentMetrics(context.Background(), "1", "", customerio.TransactionalMetricsOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "contentID")
+	}
+}
+
+func TestNewsletterContentMetricsLinks(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"links": []any{}})
+	if _, err := api.GetNewsletterContentMetricsLinks(context.Background(), "1", "5", customerio.TransactionalLinkMetricsOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/newsletters/1/contents/5/metrics/links")
+}
+
+func TestNewsletterMetrics(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetNewsletterMetrics(context.Background(), "", customerio.TransactionalMetricsOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "newsletterID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"metric": map[string]any{"series": map[string]any{}}})
+	if _, err := api.GetNewsletterMetrics(context.Background(), "1", customerio.TransactionalMetricsOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/newsletters/1/metrics")
+}
+
+func TestNewsletterMetricsLinks(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"links": []any{}})
+	if _, err := api.GetNewsletterMetricsLinks(context.Background(), "1", customerio.TransactionalLinkMetricsOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/newsletters/1/metrics/links")
+}
+
+func TestGetNewsletterMessages(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetNewsletterMessages(context.Background(), "", customerio.NewsletterMessagesOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "newsletterID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"messages": []map[string]any{{"id": "m1"}}})
+	got, err := api.GetNewsletterMessages(context.Background(), "1", customerio.NewsletterMessagesOptions{Type: customerio.NewsletterChannelInbox})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/newsletters/1/messages?type=inbox")
+	if len(got.Messages) != 1 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestSendNewsletter(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.SendNewsletter(context.Background(), "", nil); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "newsletterID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"newsletter": map[string]any{"id": 1}})
+	if _, err := api.SendNewsletter(context.Background(), "1", map[string]any{}); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "POST", "/v1/newsletters/1/send")
+}
+
+func TestScheduleNewsletter(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.ScheduleNewsletter(context.Background(), "", nil); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "newsletterID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"newsletter": map[string]any{"id": 1}})
+	data := map[string]any{"send_at": 100}
+	if _, err := api.ScheduleNewsletter(context.Background(), "1", data); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "POST", "/v1/newsletters/1/schedule")
+	assertJSONEqual(t, rec.body, data)
+}
+
+func TestNewsletterLanguage(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.CreateNewsletterLanguage(context.Background(), "", nil); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "newsletterID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"content": map[string]any{"language": "en"}})
+	data := map[string]any{"language": "en"}
+	if _, err := api.CreateNewsletterLanguage(context.Background(), "1", data); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "POST", "/v1/newsletters/1/language")
+	assertJSONEqual(t, rec.body, data)
+
+	if _, err := api.GetNewsletterLanguage(context.Background(), "1", "en"); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/newsletters/1/language/en")
+
+	if _, err := api.UpdateNewsletterLanguage(context.Background(), "1", "en", data); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "PUT", "/v1/newsletters/1/language/en")
+
+	if err := api.DeleteNewsletterLanguage(context.Background(), "1", "en"); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "DELETE", "/v1/newsletters/1/language/en")
+
+	if _, err := api.GetNewsletterLanguage(context.Background(), "1", ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "language")
+	}
+}
+
+func TestNewsletterTestGroups(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetNewsletterTestGroups(context.Background(), ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "newsletterID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"test_groups": []map[string]any{
+		{"id": 1, "name": "A", "content_ids": []int{25, 26}},
+	}})
+	got, err := api.GetNewsletterTestGroups(context.Background(), "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/newsletters/1/test_groups")
+	if len(got.TestGroups) != 1 || len(got.TestGroups[0].ContentIDs) != 2 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestCreateNewsletterTestGroup(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.CreateNewsletterTestGroup(context.Background(), ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "newsletterID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"test_group": map[string]any{"id": 1, "name": "A"}})
+	got, err := api.CreateNewsletterTestGroup(context.Background(), "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "POST", "/v1/newsletters/1/test_groups")
+	assertJSONEqual(t, rec.body, nil)
+	if got.TestGroup.ID != 1 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestNewsletterTestGroupLanguage(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.CreateNewsletterTestGroupLanguage(context.Background(), "", "1", nil); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "newsletterID")
+	}
+	if _, err := api.CreateNewsletterTestGroupLanguage(context.Background(), "1", "", nil); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "testGroupID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"content": map[string]any{"language": "en"}})
+	data := map[string]any{"language": "en"}
+	if _, err := api.CreateNewsletterTestGroupLanguage(context.Background(), "1", "1", data); err != nil {
+		t.Fatal(err)
+	}
+	// Wire path uses singular "test_group", unlike the plural "test_groups" list/create endpoints.
+	assertAPIRequest(t, rec, "POST", "/v1/newsletters/1/test_group/1/language")
+	assertJSONEqual(t, rec.body, data)
+
+	if _, err := api.GetNewsletterTestGroupLanguage(context.Background(), "1", "1", "en"); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/newsletters/1/test_group/1/language/en")
+
+	if _, err := api.UpdateNewsletterTestGroupLanguage(context.Background(), "1", "1", "en", data); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "PUT", "/v1/newsletters/1/test_group/1/language/en")
+
+	if err := api.DeleteNewsletterTestGroupLanguage(context.Background(), "1", "1", "en"); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "DELETE", "/v1/newsletters/1/test_group/1/language/en")
+
+	if _, err := api.GetNewsletterTestGroupLanguage(context.Background(), "1", "1", ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "language")
+	}
+}

--- a/objects.go
+++ b/objects.go
@@ -1,0 +1,143 @@
+package customerio
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// ObjectAttributes is the object payload returned by GetObjectAttributes.
+// ObjectTypeID is decoded leniently (json.Number) since the documented
+// schema types it as a string here but as an integer on other object
+// endpoints.
+type ObjectAttributes struct {
+	ObjectTypeID json.Number       `json:"object_type_id,omitempty"`
+	Identifiers  ObjectIdentifiers `json:"identifiers"`
+	Attributes   map[string]any    `json:"attributes,omitempty"`
+	Timestamps   map[string]int64  `json:"timestamps,omitempty"`
+}
+
+// ObjectAttributesResponse is the decoded shape of
+// GET /v1/objects/{objectTypeId}/{objectId}/attributes.
+type ObjectAttributesResponse struct {
+	Object ObjectAttributes `json:"object"`
+}
+
+// GetObjectAttributes returns an object's attributes. idType selects which
+// kind of identifier objectID is; pass "" to let the API apply its default.
+// See https://docs.customer.io/api/app/#operation/getObjectAttributes
+func (c *APIClient) GetObjectAttributes(ctx context.Context, objectTypeID, objectID string, idType ObjectIdentifierType) (*ObjectAttributesResponse, error) {
+	if objectTypeID == "" {
+		return nil, ParamError{Param: "objectTypeID"}
+	}
+	if objectID == "" {
+		return nil, ParamError{Param: "objectID"}
+	}
+
+	requestPath := formatPath("/v1/objects/%s/%s/attributes", objectTypeID, objectID) +
+		newQuery().setString("id_type", string(idType)).String()
+
+	var resp ObjectAttributesResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// ObjectRelationship is an object's relationship to a customer.
+// ObjectTypeID is decoded leniently (json.Number): see ObjectAttributes.
+type ObjectRelationship struct {
+	ObjectTypeID       json.Number         `json:"object_type_id,omitempty"`
+	ObjectTypeDisabled bool                `json:"object_type_disabled,omitempty"`
+	Identifiers        CustomerIdentifiers `json:"identifiers"`
+}
+
+// ObjectRelationshipsResponse is the decoded shape of
+// GET /v1/objects/{objectTypeId}/{objectId}/relationships.
+type ObjectRelationshipsResponse struct {
+	Relationships []ObjectRelationship `json:"cio_relationships"`
+	Next          string               `json:"next,omitempty"`
+}
+
+// ObjectRelationshipsOptions filters GetObjectRelationships.
+type ObjectRelationshipsOptions struct {
+	PaginationOptions
+	IDType ObjectIdentifierType
+}
+
+// GetObjectRelationships returns the customers related to an object.
+// See https://docs.customer.io/api/app/#operation/getObjectRelationships
+func (c *APIClient) GetObjectRelationships(ctx context.Context, objectTypeID, objectID string, opts ObjectRelationshipsOptions) (*ObjectRelationshipsResponse, error) {
+	if objectTypeID == "" {
+		return nil, ParamError{Param: "objectTypeID"}
+	}
+	if objectID == "" {
+		return nil, ParamError{Param: "objectID"}
+	}
+
+	q := opts.PaginationOptions.apply(newQuery()).setString("id_type", string(opts.IDType))
+	requestPath := formatPath("/v1/objects/%s/%s/relationships", objectTypeID, objectID) + q.String()
+
+	var resp ObjectRelationshipsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// findObjectsRequest is the POST /v1/objects body.
+type findObjectsRequest struct {
+	ObjectTypeID string       `json:"object_type_id"`
+	Filter       ObjectFilter `json:"filter"`
+}
+
+// FindObjectsResponse is the decoded shape of POST /v1/objects.
+type FindObjectsResponse struct {
+	Identifiers []ObjectIdentifiers `json:"identifiers"`
+	IDs         []string            `json:"ids"`
+	Next        string              `json:"next,omitempty"`
+}
+
+// FindObjects finds objects of type objectTypeID matching filter (built
+// with ObjectFilterByAttribute and the ObjectFilterAnd/Or/Not combinators).
+// See https://docs.customer.io/api/app/#operation/findObjects
+func (c *APIClient) FindObjects(ctx context.Context, objectTypeID string, filter ObjectFilter, opts PaginationOptions) (*FindObjectsResponse, error) {
+	if objectTypeID == "" {
+		return nil, ParamError{Param: "objectTypeID"}
+	}
+
+	requestPath := "/v1/objects" + opts.apply(newQuery()).String()
+
+	var resp FindObjectsResponse
+	req := findObjectsRequest{ObjectTypeID: objectTypeID, Filter: filter}
+	if err := c.doJSON(ctx, "POST", requestPath, req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// ObjectType describes an object type configured in a workspace (e.g. a
+// "Company" or "Concert" schema).
+type ObjectType struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	SingularName string `json:"singular_name,omitempty"`
+	Slug         string `json:"slug,omitempty"`
+	SingularSlug string `json:"singular_slug,omitempty"`
+	Enabled      bool   `json:"enabled"`
+	Icon         string `json:"icon,omitempty"`
+}
+
+// ListObjectTypesResponse is the decoded shape of GET /v1/object_types.
+type ListObjectTypesResponse struct {
+	Types []ObjectType `json:"types"`
+}
+
+// ListObjectTypes returns every object type configured in the workspace.
+// See https://docs.customer.io/api/app/#operation/listObjectTypes
+func (c *APIClient) ListObjectTypes(ctx context.Context) (*ListObjectTypesResponse, error) {
+	var resp ListObjectTypesResponse
+	if err := c.doJSON(ctx, "GET", "/v1/object_types", nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/objects_test.go
+++ b/objects_test.go
@@ -1,0 +1,138 @@
+package customerio_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/customerio/go-customerio/v3"
+)
+
+func TestGetObjectAttributes(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	ctx := context.Background()
+
+	if _, err := api.GetObjectAttributes(ctx, "", "obj1", ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "objectTypeID")
+	}
+	if _, err := api.GetObjectAttributes(ctx, "1", "", ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "objectID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"object": map[string]any{
+		"object_type_id": "1",
+		"identifiers":    map[string]any{"object_id": "ae3000"},
+		"attributes":     map[string]any{"name": "Acme"},
+	}})
+	got, err := api.GetObjectAttributes(ctx, "1", "ae3000", customerio.ObjectIdentifierTypeObjectID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/objects/1/ae3000/attributes?id_type=object_id")
+	if got.Object.Identifiers.ObjectID != "ae3000" || got.Object.Attributes["name"] != "Acme" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetObjectRelationships(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	ctx := context.Background()
+
+	if _, err := api.GetObjectRelationships(ctx, "", "obj1", customerio.ObjectRelationshipsOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "objectTypeID")
+	}
+	if _, err := api.GetObjectRelationships(ctx, "1", "", customerio.ObjectRelationshipsOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "objectID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"cio_relationships": []map[string]any{
+		{"identifiers": map[string]any{"cio_id": "cio1", "id": "acmeInc"}, "object_type_id": "1", "object_type_disabled": false},
+	}})
+	got, err := api.GetObjectRelationships(ctx, "1", "ae3000", customerio.ObjectRelationshipsOptions{
+		PaginationOptions: customerio.PaginationOptions{Limit: 20},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/objects/1/ae3000/relationships?limit=20")
+	if len(got.Relationships) != 1 || got.Relationships[0].Identifiers.ID != "acmeInc" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestFindObjects(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	ctx := context.Background()
+
+	if _, err := api.FindObjects(ctx, "", customerio.ObjectFilter{}, customerio.PaginationOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "objectTypeID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{
+		"identifiers": []map[string]any{{"cio_object_id": "ob020101", "object_id": "ae3000"}},
+		"ids":         []string{"ae3000"},
+	})
+	filter := customerio.ObjectFilterByAttribute("name", customerio.FilterOperatorEq, "Acme", 1)
+	got, err := api.FindObjects(ctx, "1", filter, customerio.PaginationOptions{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "POST", "/v1/objects?limit=10")
+
+	wantBody := map[string]any{
+		"object_type_id": "1",
+		"filter": map[string]any{
+			"object_attribute": map[string]any{"field": "name", "operator": "eq", "value": "Acme", "type_id": float64(1)},
+		},
+	}
+	assertJSONEqual(t, rec.body, wantBody)
+	if len(got.Identifiers) != 1 || got.Identifiers[0].ObjectID != "ae3000" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestFindObjectsComposedFilter(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"identifiers": []any{}, "ids": []any{}})
+
+	filter := customerio.ObjectFilterOr(
+		customerio.ObjectFilterByAttribute("tier", customerio.FilterOperatorEq, "gold", 1),
+		customerio.ObjectFilterNot(customerio.ObjectFilterByAttribute("archived", customerio.FilterOperatorExists, "", 1)),
+	)
+	if _, err := api.FindObjects(context.Background(), "1", filter, customerio.PaginationOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	wantBody := map[string]any{
+		"object_type_id": "1",
+		"filter": map[string]any{
+			"or": []any{
+				map[string]any{"object_attribute": map[string]any{"field": "tier", "operator": "eq", "value": "gold", "type_id": float64(1)}},
+				map[string]any{"not": map[string]any{"object_attribute": map[string]any{"field": "archived", "operator": "exists", "type_id": float64(1)}}},
+			},
+		},
+	}
+	assertJSONEqual(t, rec.body, wantBody)
+}
+
+func TestListObjectTypes(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"types": []map[string]any{
+		{"id": "1", "name": "Concerts", "singular_name": "Concert", "enabled": true},
+	}})
+	got, err := api.ListObjectTypes(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/object_types")
+	if len(got.Types) != 1 || got.Types[0].Name != "Concerts" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}

--- a/pagination.go
+++ b/pagination.go
@@ -1,0 +1,26 @@
+package customerio
+
+// PaginationOptions controls paging on App API list/search endpoints.
+// Start is an opaque cursor returned by a previous response's "next" field,
+// not a page number or offset — pass it back verbatim to fetch the next
+// page. Limit caps the number of results per page; 0 lets the API apply its
+// default.
+type PaginationOptions struct {
+	Start string
+	Limit int
+}
+
+func (o PaginationOptions) apply(q *queryBuilder) *queryBuilder {
+	return q.setString("start", o.Start).setInt("limit", o.Limit)
+}
+
+// ObjectIdentifierType identifies which kind of id a request supplies for an
+// object (as opposed to IdentifierType, which is for customers).
+type ObjectIdentifierType string
+
+const (
+	// ObjectIdentifierTypeObjectID selects the caller-supplied object_id.
+	ObjectIdentifierTypeObjectID ObjectIdentifierType = "object_id"
+	// ObjectIdentifierTypeCioObjectID selects Customer.io's generated cio_object_id.
+	ObjectIdentifierTypeCioObjectID ObjectIdentifierType = "cio_object_id"
+)

--- a/pagination.go
+++ b/pagination.go
@@ -24,3 +24,53 @@ const (
 	// ObjectIdentifierTypeCioObjectID selects Customer.io's generated cio_object_id.
 	ObjectIdentifierTypeCioObjectID ObjectIdentifierType = "cio_object_id"
 )
+
+// MetricType filters metrics/message reports to one delivery channel.
+type MetricType string
+
+const (
+	MetricTypeEmail    MetricType = "email"
+	MetricTypeWebhook  MetricType = "webhook"
+	MetricTypeTwilio   MetricType = "twilio"
+	MetricTypeWhatsApp MetricType = "whatsapp"
+	MetricTypeSlack    MetricType = "slack"
+	MetricTypePush     MetricType = "push"
+	MetricTypeInApp    MetricType = "in_app"
+)
+
+// NewsletterChannelType filters newsletter message reports to one delivery
+// channel — the same idea as MetricType, but newsletters support "inbox"
+// and not "whatsapp"/"slack", so it's a distinct type rather than a
+// restriction of MetricType's values.
+type NewsletterChannelType string
+
+const (
+	NewsletterChannelEmail   NewsletterChannelType = "email"
+	NewsletterChannelWebhook NewsletterChannelType = "webhook"
+	NewsletterChannelTwilio  NewsletterChannelType = "twilio"
+	NewsletterChannelPush    NewsletterChannelType = "push"
+	NewsletterChannelInApp   NewsletterChannelType = "in_app"
+	NewsletterChannelInbox   NewsletterChannelType = "inbox"
+)
+
+// MetricResolution buckets a metrics or journey-metrics report. Which of
+// the short (hours/days/weeks/months) or long (hourly/daily/weekly/
+// monthly) form an endpoint accepts is validated server-side, not here.
+type MetricResolution string
+
+// CampaignMetricsVersion selects the metrics schema for campaign/action
+// metrics: "2" adds bot-click-filtered human_*/prefetch_* series on top of "1".
+type CampaignMetricsVersion string
+
+const (
+	CampaignMetricsVersion1 CampaignMetricsVersion = "1"
+	CampaignMetricsVersion2 CampaignMetricsVersion = "2"
+)
+
+// SortDirection orders a list endpoint's results.
+type SortDirection string
+
+const (
+	SortAscending  SortDirection = "asc"
+	SortDescending SortDirection = "desc"
+)

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -1,0 +1,52 @@
+package customerio
+
+import "context"
+
+// SubscriptionTopic is a topic customers can subscribe to (e.g. "Product Updates").
+type SubscriptionTopic struct {
+	ID                  int    `json:"id"`
+	Identifier          string `json:"identifier,omitempty"`
+	Name                string `json:"name"`
+	Description         string `json:"description,omitempty"`
+	SubscribedByDefault bool   `json:"subscribed_by_default"`
+}
+
+// ListSubscriptionTopicsResponse is the decoded shape of GET /v1/subscription_topics.
+type ListSubscriptionTopicsResponse struct {
+	Topics []SubscriptionTopic `json:"topics"`
+}
+
+// ListSubscriptionTopics returns every subscription topic defined in the workspace.
+// See https://docs.customer.io/api/app/#operation/listSubscriptionTopics
+func (c *APIClient) ListSubscriptionTopics(ctx context.Context) (*ListSubscriptionTopicsResponse, error) {
+	var resp ListSubscriptionTopicsResponse
+	if err := c.doJSON(ctx, "GET", "/v1/subscription_topics", nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// SubscriptionChannel is a delivery channel (email, push, SMS, ...)
+// customers can opt in or out of.
+type SubscriptionChannel struct {
+	ID                  int    `json:"id"`
+	Type                string `json:"type"`
+	Name                string `json:"name"`
+	Description         string `json:"description,omitempty"`
+	SubscribedByDefault bool   `json:"subscribed_by_default"`
+}
+
+// ListSubscriptionChannelsResponse is the decoded shape of GET /v1/subscription_channels.
+type ListSubscriptionChannelsResponse struct {
+	Channels []SubscriptionChannel `json:"channels"`
+}
+
+// ListSubscriptionChannels returns every subscription channel defined in the workspace.
+// See https://docs.customer.io/api/app/#operation/listSubscriptionChannels
+func (c *APIClient) ListSubscriptionChannels(ctx context.Context) (*ListSubscriptionChannelsResponse, error) {
+	var resp ListSubscriptionChannelsResponse
+	if err := c.doJSON(ctx, "GET", "/v1/subscription_channels", nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -1,0 +1,34 @@
+package customerio_test
+
+import (
+	"context"
+	"testing"
+)
+
+func TestListSubscriptionTopics(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"topics": []map[string]any{
+		{"id": 4, "identifier": "topic_4", "name": "Product Updates", "subscribed_by_default": false},
+	}})
+	got, err := api.ListSubscriptionTopics(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/subscription_topics")
+	if len(got.Topics) != 1 || got.Topics[0].Name != "Product Updates" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestListSubscriptionChannels(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"channels": []map[string]any{
+		{"id": 1, "type": "email", "name": "Email", "subscribed_by_default": true},
+	}})
+	got, err := api.ListSubscriptionChannels(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/subscription_channels")
+	if len(got.Channels) != 1 || got.Channels[0].Type != "email" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}

--- a/transactional_messages.go
+++ b/transactional_messages.go
@@ -1,0 +1,319 @@
+package customerio
+
+import "context"
+
+// TransactionalMessage is a transactional message template's metadata (not
+// its content — see TransactionalMessageContent).
+type TransactionalMessage struct {
+	ID                 int    `json:"id"`
+	Name               string `json:"name,omitempty"`
+	Description        string `json:"description,omitempty"`
+	SendToUnsubscribed bool   `json:"send_to_unsubscribed"`
+	LinkTracking       bool   `json:"link_tracking"`
+	OpenTracking       bool   `json:"open_tracking"`
+	HideMessageBody    bool   `json:"hide_message_body"`
+	QueueDrafts        bool   `json:"queue_drafts"`
+	CreatedAt          int64  `json:"created_at,omitempty"`
+	UpdatedAt          int64  `json:"updated_at,omitempty"`
+}
+
+// ListTransactionalMessagesResponse is the decoded shape of GET /v1/transactional.
+type ListTransactionalMessagesResponse struct {
+	Messages []TransactionalMessage `json:"messages"`
+}
+
+// ListTransactionalMessages returns every transactional message template
+// defined in the workspace.
+// See https://docs.customer.io/api/app/#operation/listTransactionalMessages
+func (c *APIClient) ListTransactionalMessages(ctx context.Context) (*ListTransactionalMessagesResponse, error) {
+	var resp ListTransactionalMessagesResponse
+	if err := c.doJSON(ctx, "GET", "/v1/transactional", nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// TransactionalMessageResponse wraps a single TransactionalMessage.
+type TransactionalMessageResponse struct {
+	Message TransactionalMessage `json:"message"`
+}
+
+// GetTransactionalMessage returns one transactional message template's metadata.
+// See https://docs.customer.io/api/app/#operation/getTransactionalMessage
+func (c *APIClient) GetTransactionalMessage(ctx context.Context, transactionalID string) (*TransactionalMessageResponse, error) {
+	if transactionalID == "" {
+		return nil, ParamError{Param: "transactionalID"}
+	}
+
+	var resp TransactionalMessageResponse
+	if err := c.doJSON(ctx, "GET", formatPath("/v1/transactional/%s", transactionalID), nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// TransactionalMessageContent is one language variant's rendered content
+// for a transactional message template.
+type TransactionalMessageContent struct {
+	ID            int               `json:"id,omitempty"`
+	Name          string            `json:"name,omitempty"`
+	Created       int64             `json:"created,omitempty"`
+	Updated       int64             `json:"updated,omitempty"`
+	Body          string            `json:"body,omitempty"`
+	BodyAMP       string            `json:"body_amp,omitempty"`
+	Language      string            `json:"language,omitempty"`
+	Type          string            `json:"type,omitempty"`
+	From          string            `json:"from,omitempty"`
+	FromID        *int              `json:"from_id,omitempty"`
+	ReplyTo       string            `json:"reply_to,omitempty"`
+	ReplyToID     *int              `json:"reply_to_id,omitempty"`
+	Preprocessor  string            `json:"preprocessor,omitempty"`
+	Recipient     string            `json:"recipient,omitempty"`
+	Subject       string            `json:"subject,omitempty"`
+	PreheaderText string            `json:"preheader_text,omitempty"`
+	Headers       map[string]string `json:"headers,omitempty"`
+	CC            string            `json:"cc,omitempty"`
+	BCC           string            `json:"bcc,omitempty"`
+	FakeBCC       *bool             `json:"fake_bcc,omitempty"`
+}
+
+// TransactionalMessageContentsResponse is the decoded shape of
+// GET /v1/transactional/{id}/contents.
+type TransactionalMessageContentsResponse struct {
+	Contents []TransactionalMessageContent `json:"contents"`
+}
+
+// GetTransactionalMessageContents returns every language variant's content
+// for a transactional message template.
+// See https://docs.customer.io/api/app/#operation/getTransactionalMessageContents
+func (c *APIClient) GetTransactionalMessageContents(ctx context.Context, transactionalID string) (*TransactionalMessageContentsResponse, error) {
+	if transactionalID == "" {
+		return nil, ParamError{Param: "transactionalID"}
+	}
+
+	var resp TransactionalMessageContentsResponse
+	if err := c.doJSON(ctx, "GET", formatPath("/v1/transactional/%s/contents", transactionalID), nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// TransactionalMessageContentResponse wraps the content variant(s) returned
+// by the language and content-update endpoints.
+type TransactionalMessageContentResponse struct {
+	Content []TransactionalMessageContent `json:"content"`
+}
+
+// GetTransactionalMessageLanguage returns one language variant's content.
+// See https://docs.customer.io/api/app/#operation/getTransactionalMessageLanguage
+func (c *APIClient) GetTransactionalMessageLanguage(ctx context.Context, transactionalID, language string) (*TransactionalMessageContentResponse, error) {
+	if transactionalID == "" {
+		return nil, ParamError{Param: "transactionalID"}
+	}
+	if language == "" {
+		return nil, ParamError{Param: "language"}
+	}
+
+	var resp TransactionalMessageContentResponse
+	requestPath := formatPath("/v1/transactional/%s/language/%s", transactionalID, language)
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// UpdateTransactionalMessageLanguage creates or updates a language variant's
+// content. data is free-form (subject/body/etc — whichever fields you want
+// to set), matching the App API's own untyped request body for this endpoint.
+// See https://docs.customer.io/api/app/#operation/updateTransactionalMessageLanguage
+func (c *APIClient) UpdateTransactionalMessageLanguage(ctx context.Context, transactionalID, language string, data map[string]any) (*TransactionalMessageContentResponse, error) {
+	if transactionalID == "" {
+		return nil, ParamError{Param: "transactionalID"}
+	}
+	if language == "" {
+		return nil, ParamError{Param: "language"}
+	}
+
+	var resp TransactionalMessageContentResponse
+	requestPath := formatPath("/v1/transactional/%s/language/%s", transactionalID, language)
+	if err := c.doJSON(ctx, "PUT", requestPath, data, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// TransactionalDeliveriesOptions filters GetTransactionalMessageDeliveries.
+type TransactionalDeliveriesOptions struct {
+	PaginationOptions
+	Metric              string
+	StartTS             int64
+	EndTS               int64
+	GetTrackedResponses *bool
+}
+
+// TransactionalDeliveriesResponse is the decoded shape of
+// GET /v1/transactional/{id}/messages.
+type TransactionalDeliveriesResponse struct {
+	Messages []Message `json:"messages"`
+}
+
+// GetTransactionalMessageDeliveries returns the messages sent from a
+// transactional message template.
+// See https://docs.customer.io/api/app/#operation/getTransactionalMessageDeliveries
+func (c *APIClient) GetTransactionalMessageDeliveries(ctx context.Context, transactionalID string, opts TransactionalDeliveriesOptions) (*TransactionalDeliveriesResponse, error) {
+	if transactionalID == "" {
+		return nil, ParamError{Param: "transactionalID"}
+	}
+
+	q := opts.PaginationOptions.apply(newQuery()).
+		setString("metric", opts.Metric).
+		setInt64("start_ts", opts.StartTS).
+		setInt64("end_ts", opts.EndTS).
+		setBool("get_tracked_responses", opts.GetTrackedResponses)
+
+	requestPath := formatPath("/v1/transactional/%s/messages", transactionalID) + q.String()
+
+	var resp TransactionalDeliveriesResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// MetricsPeriod buckets a metrics time series into hours/days/weeks/months.
+type MetricsPeriod string
+
+const (
+	MetricsPeriodHours  MetricsPeriod = "hours"
+	MetricsPeriodDays   MetricsPeriod = "days"
+	MetricsPeriodWeeks  MetricsPeriod = "weeks"
+	MetricsPeriodMonths MetricsPeriod = "months"
+)
+
+// TransactionalMetricsOptions controls the time series window for
+// GetTransactionalMessageMetrics.
+type TransactionalMetricsOptions struct {
+	Period MetricsPeriod
+	Steps  int
+}
+
+// MetricSeries is a set of per-bucket counts, one entry per event kind that
+// applies to the resource being measured.
+type MetricSeries struct {
+	Attempted         []int `json:"attempted,omitempty"`
+	Bounced           []int `json:"bounced,omitempty"`
+	Clicked           []int `json:"clicked,omitempty"`
+	HumanClicked      []int `json:"human_clicked,omitempty"`
+	PrefetchClicked   []int `json:"prefetch_clicked,omitempty"`
+	Converted         []int `json:"converted,omitempty"`
+	Created           []int `json:"created,omitempty"`
+	Deferred          []int `json:"deferred,omitempty"`
+	Delivered         []int `json:"delivered,omitempty"`
+	Drafted           []int `json:"drafted,omitempty"`
+	Failed            []int `json:"failed,omitempty"`
+	Opened            []int `json:"opened,omitempty"`
+	HumanOpened       []int `json:"human_opened,omitempty"`
+	PrefetchOpened    []int `json:"prefetch_opened,omitempty"`
+	Sent              []int `json:"sent,omitempty"`
+	Spammed           []int `json:"spammed,omitempty"`
+	Suppressed        []int `json:"suppressed,omitempty"`
+	Undeliverable     []int `json:"undeliverable,omitempty"`
+	TopicUnsubscribed []int `json:"topic_unsubscribed,omitempty"`
+	Unsubscribed      []int `json:"unsubscribed,omitempty"`
+}
+
+// TransactionalMetricsResponse is the decoded shape of
+// GET /v1/transactional/{id}/metrics.
+type TransactionalMetricsResponse struct {
+	Metric struct {
+		Series MetricSeries `json:"series"`
+	} `json:"metric"`
+}
+
+// GetTransactionalMessageMetrics returns send/delivery/engagement counts
+// over time for a transactional message template.
+// See https://docs.customer.io/api/app/#operation/getTransactionalMessageMetrics
+func (c *APIClient) GetTransactionalMessageMetrics(ctx context.Context, transactionalID string, opts TransactionalMetricsOptions) (*TransactionalMetricsResponse, error) {
+	if transactionalID == "" {
+		return nil, ParamError{Param: "transactionalID"}
+	}
+
+	q := newQuery().setString("period", string(opts.Period)).setInt("steps", opts.Steps)
+	requestPath := formatPath("/v1/transactional/%s/metrics", transactionalID) + q.String()
+
+	var resp TransactionalMetricsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// TransactionalLinkMetricsOptions controls GetTransactionalMessageLinkMetrics.
+type TransactionalLinkMetricsOptions struct {
+	TransactionalMetricsOptions
+	Unique *bool
+}
+
+// LinkMetricSeries is per-bucket click counts for one link.
+type LinkMetricSeries struct {
+	Clicked        []int `json:"clicked,omitempty"`
+	HumanClicked   []int `json:"human_clicked,omitempty"`
+	MachineClicked []int `json:"machine_clicked,omitempty"`
+}
+
+// LinkMetric is one tracked link's click metrics.
+type LinkMetric struct {
+	Link struct {
+		ID   string `json:"id,omitempty"`
+		Href string `json:"href,omitempty"`
+	} `json:"link"`
+	Metric struct {
+		Series LinkMetricSeries `json:"series"`
+	} `json:"metric"`
+}
+
+// TransactionalLinkMetricsResponse is the decoded shape of
+// GET /v1/transactional/{id}/metrics/links.
+type TransactionalLinkMetricsResponse struct {
+	Links []LinkMetric `json:"links"`
+}
+
+// GetTransactionalMessageLinkMetrics returns per-link click metrics for a
+// transactional message template.
+// See https://docs.customer.io/api/app/#operation/getTransactionalMessageLinkMetrics
+func (c *APIClient) GetTransactionalMessageLinkMetrics(ctx context.Context, transactionalID string, opts TransactionalLinkMetricsOptions) (*TransactionalLinkMetricsResponse, error) {
+	if transactionalID == "" {
+		return nil, ParamError{Param: "transactionalID"}
+	}
+
+	q := newQuery().
+		setString("period", string(opts.Period)).
+		setInt("steps", opts.Steps).
+		setBool("unique", opts.Unique)
+	requestPath := formatPath("/v1/transactional/%s/metrics/links", transactionalID) + q.String()
+
+	var resp TransactionalLinkMetricsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// UpdateTransactionalMessageContent updates one content variant by id. data
+// is free-form, matching the App API's own untyped request body.
+// See https://docs.customer.io/api/app/#operation/updateTransactionalMessageContent
+func (c *APIClient) UpdateTransactionalMessageContent(ctx context.Context, transactionalID, contentID string, data map[string]any) (*TransactionalMessageContentResponse, error) {
+	if transactionalID == "" {
+		return nil, ParamError{Param: "transactionalID"}
+	}
+	if contentID == "" {
+		return nil, ParamError{Param: "contentID"}
+	}
+
+	var resp TransactionalMessageContentResponse
+	requestPath := formatPath("/v1/transactional/%s/content/%s", transactionalID, contentID)
+	if err := c.doJSON(ctx, "PUT", requestPath, data, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/transactional_messages.go
+++ b/transactional_messages.go
@@ -155,6 +155,7 @@ type TransactionalDeliveriesOptions struct {
 // GET /v1/transactional/{id}/messages.
 type TransactionalDeliveriesResponse struct {
 	Messages []Message `json:"messages"`
+	Next     string    `json:"next,omitempty"`
 }
 
 // GetTransactionalMessageDeliveries returns the messages sent from a

--- a/transactional_messages.go
+++ b/transactional_messages.go
@@ -198,7 +198,12 @@ type TransactionalMetricsOptions struct {
 }
 
 // MetricSeries is a set of per-bucket counts, one entry per event kind that
-// applies to the resource being measured.
+// applies to the resource being measured. This is the full superset of
+// fields the App API reports across every metered resource (transactional
+// messages, campaigns, campaign/broadcast actions, broadcasts,
+// newsletters/newsletter content); which fields are actually populated
+// depends on the resource and channel. The StatusCode* fields only apply
+// to webhook actions.
 type MetricSeries struct {
 	Attempted         []int `json:"attempted,omitempty"`
 	Bounced           []int `json:"bounced,omitempty"`
@@ -220,10 +225,17 @@ type MetricSeries struct {
 	Undeliverable     []int `json:"undeliverable,omitempty"`
 	TopicUnsubscribed []int `json:"topic_unsubscribed,omitempty"`
 	Unsubscribed      []int `json:"unsubscribed,omitempty"`
+	StatusCode2xx     []int `json:"2xx,omitempty"`
+	StatusCode3xx     []int `json:"3xx,omitempty"`
+	StatusCode4xx     []int `json:"4xx,omitempty"`
+	StatusCode5xx     []int `json:"5xx,omitempty"`
 }
 
-// TransactionalMetricsResponse is the decoded shape of
-// GET /v1/transactional/{id}/metrics.
+// TransactionalMetricsResponse wraps a MetricSeries report. Despite the
+// name (kept for API stability with where it was first introduced), the
+// App API returns this identical {metric:{series:{...}}} shape for every
+// metered resource, so it's reused as-is by campaign/broadcast/newsletter
+// metrics methods rather than duplicated per resource.
 type TransactionalMetricsResponse struct {
 	Metric struct {
 		Series MetricSeries `json:"series"`
@@ -272,8 +284,9 @@ type LinkMetric struct {
 	} `json:"metric"`
 }
 
-// TransactionalLinkMetricsResponse is the decoded shape of
-// GET /v1/transactional/{id}/metrics/links.
+// TransactionalLinkMetricsResponse wraps per-link click metrics. Like
+// TransactionalMetricsResponse, this shape is shared across every metered
+// resource's .../metrics/links endpoint, not just transactional messages.
 type TransactionalLinkMetricsResponse struct {
 	Links []LinkMetric `json:"links"`
 }

--- a/transactional_messages_test.go
+++ b/transactional_messages_test.go
@@ -1,0 +1,203 @@
+package customerio_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/customerio/go-customerio/v3"
+)
+
+func TestListTransactionalMessages(t *testing.T) {
+	api, rec := apiServer(t, 200, map[string]any{"messages": []map[string]any{
+		{"id": 1, "name": "Welcome"},
+	}})
+	got, err := api.ListTransactionalMessages(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/transactional")
+	if len(got.Messages) != 1 || got.Messages[0].Name != "Welcome" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetTransactionalMessage(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetTransactionalMessage(context.Background(), ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "transactionalID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"message": map[string]any{"id": 1, "name": "Welcome"}})
+	got, err := api.GetTransactionalMessage(context.Background(), "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/transactional/1")
+	if got.Message.Name != "Welcome" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetTransactionalMessageContents(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetTransactionalMessageContents(context.Background(), ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "transactionalID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"contents": []map[string]any{
+		{"id": 1, "language": "en", "subject": "hi"},
+	}})
+	got, err := api.GetTransactionalMessageContents(context.Background(), "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/transactional/1/contents")
+	if len(got.Contents) != 1 || got.Contents[0].Subject != "hi" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetTransactionalMessageLanguage(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetTransactionalMessageLanguage(context.Background(), "", "en"); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "transactionalID")
+	}
+	if _, err := api.GetTransactionalMessageLanguage(context.Background(), "1", ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "language")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"content": []map[string]any{{"language": "en", "subject": "hi"}}})
+	got, err := api.GetTransactionalMessageLanguage(context.Background(), "1", "en")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/transactional/1/language/en")
+	if len(got.Content) != 1 || got.Content[0].Language != "en" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestUpdateTransactionalMessageLanguage(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.UpdateTransactionalMessageLanguage(context.Background(), "", "en", nil); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "transactionalID")
+	}
+	if _, err := api.UpdateTransactionalMessageLanguage(context.Background(), "1", "", nil); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "language")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"content": []map[string]any{{"language": "en"}}})
+	data := map[string]any{"subject": "updated"}
+	if _, err := api.UpdateTransactionalMessageLanguage(context.Background(), "1", "en", data); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "PUT", "/v1/transactional/1/language/en")
+	assertJSONEqual(t, rec.body, data)
+}
+
+func TestGetTransactionalMessageDeliveries(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetTransactionalMessageDeliveries(context.Background(), "", customerio.TransactionalDeliveriesOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "transactionalID")
+	}
+
+	tracked := true
+	api, rec := apiServer(t, 200, map[string]any{"messages": []map[string]any{{"id": "m1", "subject": "hi"}}})
+	got, err := api.GetTransactionalMessageDeliveries(context.Background(), "1", customerio.TransactionalDeliveriesOptions{
+		Metric:              "opened",
+		StartTS:             100,
+		EndTS:               200,
+		GetTrackedResponses: &tracked,
+		PaginationOptions:   customerio.PaginationOptions{Limit: 10},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/transactional/1/messages?end_ts=200&get_tracked_responses=true&limit=10&metric=opened&start_ts=100")
+	if len(got.Messages) != 1 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetTransactionalMessageMetrics(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetTransactionalMessageMetrics(context.Background(), "", customerio.TransactionalMetricsOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "transactionalID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"metric": map[string]any{"series": map[string]any{"sent": []int{1, 2, 3}}}})
+	got, err := api.GetTransactionalMessageMetrics(context.Background(), "1", customerio.TransactionalMetricsOptions{
+		Period: customerio.MetricsPeriodDays,
+		Steps:  7,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/transactional/1/metrics?period=days&steps=7")
+	if len(got.Metric.Series.Sent) != 3 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetTransactionalMessageLinkMetrics(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetTransactionalMessageLinkMetrics(context.Background(), "", customerio.TransactionalLinkMetricsOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "transactionalID")
+	}
+
+	unique := true
+	api, rec := apiServer(t, 200, map[string]any{"links": []map[string]any{
+		{"link": map[string]any{"id": "l1", "href": "https://example.com"}, "metric": map[string]any{"series": map[string]any{"clicked": []int{1}}}},
+	}})
+	got, err := api.GetTransactionalMessageLinkMetrics(context.Background(), "1", customerio.TransactionalLinkMetricsOptions{
+		TransactionalMetricsOptions: customerio.TransactionalMetricsOptions{Period: customerio.MetricsPeriodWeeks, Steps: 4},
+		Unique:                      &unique,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/transactional/1/metrics/links?period=weeks&steps=4&unique=true")
+	if len(got.Links) != 1 || got.Links[0].Link.Href != "https://example.com" {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestUpdateTransactionalMessageContent(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.UpdateTransactionalMessageContent(context.Background(), "", "c1", nil); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "transactionalID")
+	}
+	if _, err := api.UpdateTransactionalMessageContent(context.Background(), "1", "", nil); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "contentID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"content": []map[string]any{{"id": 5}}})
+	data := map[string]any{"body": "updated"}
+	if _, err := api.UpdateTransactionalMessageContent(context.Background(), "1", "5", data); err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "PUT", "/v1/transactional/1/content/5")
+	assertJSONEqual(t, rec.body, data)
+}

--- a/trigger_broadcast.go
+++ b/trigger_broadcast.go
@@ -121,3 +121,63 @@ func buildBroadcastPayload(in broadcastInput) broadcastPayload {
 
 	return p
 }
+
+// BroadcastTriggerStatus reports one broadcast trigger's processing state.
+type BroadcastTriggerStatus struct {
+	ID          int   `json:"id"`
+	BroadcastID int   `json:"broadcast_id,omitempty"`
+	CreatedAt   int64 `json:"created_at,omitempty"`
+	ProcessedAt int64 `json:"processed_at,omitempty"`
+}
+
+// GetBroadcastTriggerStatus returns one broadcast trigger's processing
+// state. Despite the "broadcast" naming, this addresses
+// /v1/campaigns/{broadcastID}/triggers/{triggerID} — the App API files
+// broadcast triggers under the campaigns resource; GetBroadcastTriggers
+// (broadcasts.go) is the analogous list endpoint under /v1/broadcasts/{id}/triggers.
+// See https://docs.customer.io/api/app/#operation/getBroadcastTriggerStatus
+func (c *APIClient) GetBroadcastTriggerStatus(ctx context.Context, broadcastID, triggerID string) (*BroadcastTriggerStatus, error) {
+	if broadcastID == "" {
+		return nil, ParamError{Param: "broadcastID"}
+	}
+	if triggerID == "" {
+		return nil, ParamError{Param: "triggerID"}
+	}
+
+	requestPath := formatPath("/v1/campaigns/%s/triggers/%s", broadcastID, triggerID)
+
+	var resp BroadcastTriggerStatus
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// BroadcastTriggerErrorsResponse is the decoded shape of
+// GET /v1/campaigns/{broadcastID}/triggers/{triggerID}/errors. Unlike most
+// other paginated App API responses, Next here is a numeric offset, not an
+// opaque string cursor.
+type BroadcastTriggerErrorsResponse struct {
+	Errors []string `json:"errors"`
+	Next   int      `json:"next,omitempty"`
+}
+
+// GetBroadcastTriggerErrors returns the per-recipient errors from one
+// broadcast trigger (e.g. "line 4: invalid email").
+// See https://docs.customer.io/api/app/#operation/getBroadcastTriggerErrors
+func (c *APIClient) GetBroadcastTriggerErrors(ctx context.Context, broadcastID, triggerID string, opts PaginationOptions) (*BroadcastTriggerErrorsResponse, error) {
+	if broadcastID == "" {
+		return nil, ParamError{Param: "broadcastID"}
+	}
+	if triggerID == "" {
+		return nil, ParamError{Param: "triggerID"}
+	}
+
+	requestPath := formatPath("/v1/campaigns/%s/triggers/%s/errors", broadcastID, triggerID) + opts.apply(newQuery()).String()
+
+	var resp BroadcastTriggerErrorsResponse
+	if err := c.doJSON(ctx, "GET", requestPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/trigger_broadcast_test.go
+++ b/trigger_broadcast_test.go
@@ -356,3 +356,51 @@ func TestTriggerBroadcastCompanionOptionsIsolation(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestGetBroadcastTriggerStatus(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetBroadcastTriggerStatus(context.Background(), "", "9"); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "broadcastID")
+	}
+	if _, err := api.GetBroadcastTriggerStatus(context.Background(), "1", ""); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "triggerID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"id": 9, "broadcast_id": 1, "created_at": 100, "processed_at": 200})
+	got, err := api.GetBroadcastTriggerStatus(context.Background(), "1", "9")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/campaigns/1/triggers/9")
+	if got.ID != 9 || got.ProcessedAt != 200 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}
+
+func TestGetBroadcastTriggerErrors(t *testing.T) {
+	api := customerio.NewAPIClient("myKey")
+	if _, err := api.GetBroadcastTriggerErrors(context.Background(), "", "9", customerio.PaginationOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "broadcastID")
+	}
+	if _, err := api.GetBroadcastTriggerErrors(context.Background(), "1", "", customerio.PaginationOptions{}); err == nil {
+		t.Fatal("expected error")
+	} else {
+		checkParamError(t, err, "triggerID")
+	}
+
+	api, rec := apiServer(t, 200, map[string]any{"errors": []string{"line 4: invalid email"}, "next": 10})
+	got, err := api.GetBroadcastTriggerErrors(context.Background(), "1", "9", customerio.PaginationOptions{Limit: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAPIRequest(t, rec, "GET", "/v1/campaigns/1/triggers/9/errors?limit=5")
+	if len(got.Errors) != 1 || got.Next != 10 {
+		t.Errorf("unexpected response: %#v", got)
+	}
+}

--- a/url.go
+++ b/url.go
@@ -3,6 +3,7 @@ package customerio
 import (
 	"fmt"
 	"net/url"
+	"strconv"
 )
 
 // formatPath builds a request path from a printf-style format string, escaping
@@ -19,4 +20,54 @@ func formatPath(format string, args ...any) string {
 		}
 	}
 	return fmt.Sprintf(format, args...)
+}
+
+// queryBuilder accumulates optional query parameters, skipping any left at
+// their zero value — mirroring the App API's own buildQueryString helper
+// (see customerio-node lib/utils.ts), which omits null/undefined/empty
+// values rather than sending them as empty query params.
+type queryBuilder struct {
+	values url.Values
+}
+
+func newQuery() *queryBuilder {
+	return &queryBuilder{values: url.Values{}}
+}
+
+func (q *queryBuilder) setString(key, value string) *queryBuilder {
+	if value != "" {
+		q.values.Set(key, value)
+	}
+	return q
+}
+
+func (q *queryBuilder) setInt(key string, value int) *queryBuilder {
+	if value != 0 {
+		q.values.Set(key, strconv.Itoa(value))
+	}
+	return q
+}
+
+func (q *queryBuilder) setBool(key string, value *bool) *queryBuilder {
+	if value != nil {
+		q.values.Set(key, strconv.FormatBool(*value))
+	}
+	return q
+}
+
+func (q *queryBuilder) setInt64(key string, value int64) *queryBuilder {
+	if value != 0 {
+		q.values.Set(key, strconv.FormatInt(value, 10))
+	}
+	return q
+}
+
+// String renders the accumulated parameters as a "?"-prefixed query string,
+// or "" if no parameter was ever set.
+func (q *queryBuilder) String() string {
+	encoded := q.values.Encode()
+	if encoded == "" {
+		return ""
+	}
+	return "?" + encoded
 }


### PR DESCRIPTION
## Summary

Follow-up to #81/#82 — ports the Node SDK's Campaign/Broadcast/Newsletter management methods:

- **Campaigns**: `ListCampaigns`, `GetCampaign`, `Get/UpdateCampaignAction`, `Get/UpdateCampaignActionLanguage`, `GetCampaignActions`, `Get(Link)Metrics` at both the action and campaign level, `GetCampaignJourneyMetrics`, `GetCampaignMessages`.
- **Broadcasts**: mirrors the campaign shape (`ListBroadcasts`, `GetBroadcast`, actions, metrics, messages), plus `GetBroadcastTriggers` and — filed under `trigger_broadcast.go` since they address the same `/campaigns/{id}/triggers` path as the existing `TriggerBroadcast` — `GetBroadcastTriggerStatus` and `GetBroadcastTriggerErrors`.
- **Newsletters**: full CRUD (`List/Create/Get/DeleteNewsletter`), content variants, metrics, messages, `Send/ScheduleNewsletter`, newsletter-level language variants, and A/B test groups (including their own nested language variants under a singular `test_group` path segment, unlike the plural `test_groups` used by the list/create endpoints — a real API path inconsistency, preserved and documented rather than "fixed").

## Notes on shapes

- Extends the shared `MetricSeries` type (from #82) with the webhook status-code buckets (`2xx`/`3xx`/`4xx`/`5xx`) this group's endpoints populate, and generalizes `TransactionalMetricsResponse`/`TransactionalLinkMetricsResponse`'s doc comments — the App API returns the identical `{metric:{series:{...}}}` shape for every metered resource (campaigns, broadcasts, newsletters), not just transactional messages, so those types are reused as-is rather than duplicated per resource.
- Request shapes cross-checked against `customerio-node`'s `lib/api.ts`; response shapes against the published App API OpenAPI spec.
- A couple of endpoints have no documented example response and are modeled by consistency with sibling endpoints rather than guessed from scratch — flagged in code comments (`GetBroadcastTriggers`' per-item shape, `Send/ScheduleNewsletter`'s response).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `golangci-lint run ./...` (v2.11.3, matching this repo's CI)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large additive API surface with many outbound calls and some free-form `map[string]any` update bodies; mistakes in paths or query encoding could affect production integrations, but existing behavior is mostly unchanged aside from the new `doJSON` helper.
> 
> **Overview**
> This PR substantially **expands the Go App API client** beyond the existing trigger/export surface, using a new **`doJSON`** helper on `APIClient` for JSON request/response handling (including optional non-200 success statuses for deletes) and a **`queryBuilder`** that omits zero-value query params.
> 
> **Campaigns, broadcasts, and newsletters** get full read/update flows: list/get resources, paginated or unpaginated actions, language variants, time-series and link metrics, message listings, and campaign **journey metrics**. Broadcasts also expose **`GetBroadcastTriggers`**; **`GetBroadcastTriggerStatus`** and **`GetBroadcastTriggerErrors`** are added under `trigger_broadcast.go` on the documented `/v1/campaigns/{id}/triggers/...` paths. Newsletters add CRUD, send/schedule, content and A/B **test group** language routes (including the API’s singular `test_group` vs plural `test_groups` paths).
> 
> **Customers, objects, segments, and workspace data** are covered with search/filter builders (`AudienceFilter` / `ObjectFilter`), profile and relationship APIs, **`ListActivities`**, global and per-customer messages (plus archived message fetch), app **segment** management, subscription topics/channels, and transactional template metrics/content updates. Shared types such as **`TransactionalMetricsResponse`** / **`MetricSeries`** are reused across metered resources, with webhook status-code buckets added where needed.
> 
> Tests use a new **`apiServer`** httptest harness with **`assertAPIRequest`** / **`assertJSONEqual`** across the new endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be1820f34124837d3e795cebc7510ca01073fd27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->